### PR TITLE
Make DebugHandler add debug flag without replacing other flags

### DIFF
--- a/cli/debugapp.go
+++ b/cli/debugapp.go
@@ -40,9 +40,7 @@ type ErrorStringer func(err error) string
 // error's "ExitCode" function; otherwise, it returns 1.
 func DebugHandler(errorStringer ErrorStringer) Option {
 	return func(app *App) {
-		app.Flags = []flag.Flag{
-			debugFlag,
-		}
+		app.Flags = append(app.Flags, debugFlag)
 		app.ErrorHandler = func(ctx Context, err error) int {
 			if ctx.Bool(DebugFlagName) && errorStringer != nil {
 				if msg := errorStringer(err); msg != "" {


### PR DESCRIPTION
Fixes issue where adding a DebugHandler to a cli.App would
overwrite all flags that were previously defined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/7)
<!-- Reviewable:end -->
