### PR TITLE
Update gödel to 0.11.1

### DIFF
--- a/godel/config/godel.properties
+++ b/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/0.11.0/godel-0.11.0.tgz
-distributionSHA256=ee8e571e2153b02673192ee5a6f2786ecc7ee73cecd1a4b7527be6cb751ac5fc
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/0.11.1/godel-0.11.1.tgz
+distributionSHA256=01dde9336b284ba26952a19d741fd97be1fde2d61c8684b5c04f9e4fae17571f

--- a/godelw
+++ b/godelw
@@ -3,17 +3,31 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=0.11.0
-DARWIN_CHECKSUM=436a2779d535d5657a9f4de6d198c5a1b64bf33513ffe38611968df7f6ca9b7f
-LINUX_CHECKSUM=7a9630f8a6f8535e2f8ada57524fae095fa3348c9f98a473bf78270e01f1dee1
+VERSION=0.11.1
+DARWIN_CHECKSUM=c6a2e803afbdad1a2ee918e34f886a92534a7d191a87bb8eac33164cd23cdbbf
+LINUX_CHECKSUM=4874e222083c69adfe8a715063033061f1299a9fd52f94cee045bcefa3885c8a
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {
     local url=$1
     local dst=$2
 
-    if command -v wget >/dev/null 2>&1; then
-        # if wget command exists, download using wget
+    # determine whether wget, curl or both are present
+    set +e
+    command -v wget >/dev/null 2>&1
+    local wget_exists=$?
+    command -v curl >/dev/null 2>&1
+    local curl_exists=$?
+    set -e
+
+    # if one of wget or curl is not present, exit with error
+    if [ "$wget_exists" -ne 0 -a "$curl_exists" -ne 0 ]; then
+        echo "wget or curl must be present to download distribution. Install one of these programs and try again or install the distribution manually."
+        exit 1
+    fi
+
+    if [ "$wget_exists" -eq 0 ]; then
+        # attempt download using wget
         echo "Downloading $url to $dst..."
         local progress_opt=""
         if wget --help | grep -q '\--show-progress'; then
@@ -23,23 +37,35 @@ function download {
         wget -O "$dst" $progress_opt "$url"
         rv=$?
         set -e
-        if [ ! $rv -eq 0 ]; then
-            echo "Download failed"
+        if [ "$rv" -eq 0 ]; then
+            # success
+            return
+        fi
+
+        echo "Download failed using command: wget -O $dst $progress_opt $url"
+
+        # curl does not exist, so nothing more to try: exit
+        if [ "$curl_exists" -ne 0 ]; then
+            echo "Download failed using wget and curl was not found. Verify that the distribution URL is correct and try again or install the distribution manually."
             exit 1
         fi
-    elif command -v curl >/dev/null 2>&1; then
-        # if curl command exists, download using curl
-        echo "Downloading $url to $dst..."
-        set +e
-        curl -o "$dst" "$url"
-        rv=$?
-        set -e
-        if [ ! $rv -eq 0 ]; then
-            echo "Download failed"
-            exit 1
+        # curl exists, notify that download will be attempted using curl
+        echo "Attempting download using curl..."
+    fi
+
+    # attempt download using curl
+    echo "Downloading $url to $dst..."
+    set +e
+    curl -f -L -o "$dst" "$url"
+    rv=$?
+    set -e
+    if [ "$rv" -ne 0 ]; then
+        echo "Download failed using command: curl -f -L -o $dst $url"
+        if [ "$wget_exists" -eq 0 ]; then
+            echo "Download failed using wget and curl. Verify that the distribution URL is correct and try again or install the distribution manually."
+        else
+            echo "Download failed using curl and wget was not found. Verify that the distribution URL is correct and try again or install the distribution manually."
         fi
-    else
-        echo "wget or curl must be present to execute download"
         exit 1
     fi
 }
@@ -50,7 +76,7 @@ function verify_checksum {
     local file=$1
     local expected_checksum=$2
     local computed_checksum=$(compute_sha256 $file)
-    if [ ! $expected_checksum = $computed_checksum ]; then
+    if [ "$expected_checksum" != "$computed_checksum" ]; then
         echo "SHA-256 checksum for $file did not match expected value."
         echo "Expected: $expected_checksum"
         echo "Actual:   $computed_checksum"


### PR DESCRIPTION
Includes fix that allows the downloading of the distribution to
fall back to using curl if downloading using wget fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/20)
<!-- Reviewable:end -->
