### PR TITLE
Make PackagesInDir ignore errors on excluded paths

### DIFF
--- a/pkgpath/packages.go
+++ b/pkgpath/packages.go
@@ -235,6 +235,13 @@ func PackagesInDir(rootDir string, exclude matcher.Matcher) (Packages, error) {
 
 	allPkgs := make(map[string]string)
 	if err := filepath.Walk(dirAbsolutePath, func(currPath string, currInfo os.FileInfo, err error) error {
+		currRelPath, currRelPathErr := filepath.Rel(dirAbsolutePath, currPath)
+
+		// skip current path if it matches an exclude
+		if currRelPathErr == nil && exclude != nil && exclude.Match(currRelPath) {
+			return nil
+		}
+
 		if err != nil {
 			return err
 		}
@@ -243,14 +250,8 @@ func PackagesInDir(rootDir string, exclude matcher.Matcher) (Packages, error) {
 			return nil
 		}
 
-		currRelPath, err := filepath.Rel(dirAbsolutePath, currPath)
-		if err != nil {
-			return err
-		}
-
-		// if current path matches an include and does not match the exclude, include
-		if exclude != nil && exclude.Match(currRelPath) {
-			return nil
+		if currRelPathErr != nil {
+			return currRelPathErr
 		}
 
 		// create a filter for processing package files that only passes if it does not match an exclude


### PR DESCRIPTION
Fixes issue where "PackagesInDir" would fail if the executing
user could not read a file or directory in the provided rootDir,
even if the file or directory was excluded by the exclude matcher.

Cannot add test because there is no way to reliably simulate an
unreadable file/directory in a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/46)
<!-- Reviewable:end -->
