### PR TITLE
Do not transform big.Float while encoding json for perf reasons

### DIFF
--- a/safejson/gocd_imports.json
+++ b/safejson/gocd_imports.json
@@ -1,14 +1,5 @@
 {
-    "imports": [
-        {
-            "path": "github.com/palantir/pkg/transform",
-            "numGoFiles": 2,
-            "numImportedGoFiles": 0,
-            "importedFrom": [
-                "github.com/palantir/pkg/safejson"
-            ]
-        }
-    ],
+    "imports": [],
     "mainOnlyImports": [],
     "testOnlyImports": [
         {

--- a/safejson/marshal.go
+++ b/safejson/marshal.go
@@ -7,19 +7,16 @@
 //
 // - json.Decoder.UseNumber
 // - json.Encoder.SetEscapeHTML(false)
-// - json.Encoder.Encode(big floats as json.Number)
 package safejson
 
 import (
 	"bytes"
 	"encoding/json"
-	"math/big"
-
-	"github.com/palantir/pkg/transform"
 )
 
 // Marshal returns the JSON encoding of v.
 func Marshal(v interface{}) ([]byte, error) {
+	// go through Encoder to control SetEscapeHTML
 	var buf bytes.Buffer
 	if err := NewEncoder(&buf).Encode(v); err != nil {
 		return nil, err
@@ -55,18 +52,5 @@ type Encoder struct {
 // See the documentation for json.Marshal for details about the conversion of Go
 // values to JSON.
 func (e *Encoder) Encode(v interface{}) error {
-	return e.enc.Encode(bigFloatToJSONNumber(v))
-}
-
-// bigFloatToJSONNumber returns json.Number in place of big.Float.
-//
-// This is necessary because big.Float's text marshaller turns them into normal
-// strings. For usage, see Encoder.Encode.
-func bigFloatToJSONNumber(obj interface{}) interface{} {
-	rules := transform.Rules{
-		func(bf *big.Float) json.Number {
-			return json.Number(bf.Text('g', -1))
-		},
-	}
-	return rules.Apply(obj)
+	return e.enc.Encode(v)
 }

--- a/safejson/marshal_test.go
+++ b/safejson/marshal_test.go
@@ -25,6 +25,14 @@ var encodeTests = map[string]struct {
 		in:   big.NewFloat(3.14),
 		want: `"3.14"`,
 	},
+	"struct containing *big.Float": {
+		in:   struct{ Foo *big.Float }{Foo: big.NewFloat(3.14)},
+		want: `{"Foo":"3.14"}`,
+	},
+	"slice of *big.Float": {
+		in:   []*big.Float{big.NewFloat(3.14), big.NewFloat(8.42)},
+		want: `["3.14","8.42"]`,
+	},
 }
 
 func TestEncoder(t *testing.T) {


### PR DESCRIPTION
transform.Rules.Apply does not properly convert *big.Float to
json.Number: it has always returned a *big.Float. We should stop
applying this no-op transformation, because it is exorbitantly costly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/49)
<!-- Reviewable:end -->
