### PR TITLE
Fix '--help' subcommand bug

### DIFF
--- a/cli/help.go
+++ b/cli/help.go
@@ -20,7 +20,7 @@ const appHelpTemplate = `NAME:
    {{.Name}} - {{.Usage}}
 
 USAGE:
-   {{.Name}}{{if .Flags}} [global flags]{{end}}{{if .Subcommands}} command [command flags]{{end}}{{if .Description}}
+   {{.Name}}{{if .Flags}} [global flags]{{end}}{{if anyCommands .Subcommands}} command [command flags]{{end}}{{if .Description}}
 
 DESCRIPTION:
    {{.Description}}{{end}}{{if anyCommands .Subcommands}}


### PR DESCRIPTION
'--help' should only reference subcommands if there is at least
one non-hidden subcommand.

Fixes #53

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/54)
<!-- Reviewable:end -->
