### PR TITLE
Add tableprinter

### DIFF
--- a/tableprinter/tableprinter.go
+++ b/tableprinter/tableprinter.go
@@ -1,0 +1,131 @@
+// Copyright 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package tableprinter implements a pretty printer that writes rows and columns
+// as a formatted table.
+package tableprinter
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+// A ColumnGetter returns the selected ColumnGetter value of a row.
+type ColumnGetter func(row interface{}) string
+
+// A Printer is a formatter for writing tables.
+//
+// The header of the table is written by formatting the column names. The body
+// of the table is written by formatting each row using the selected columns in
+// the given order.
+type Printer struct {
+	tw                     *tabwriter.Writer
+	get                    map[string]ColumnGetter // ColumnGetters by column name
+	sorted                 bool                    // whether or not to sort the body
+	includeHeader          bool                    // whether or not to print the column headers
+	includeHeaderSeparator bool                    // whether or not to print '-' characters under the column headers (only used if includeHeader is true)
+}
+
+// New returns a new Printer backed by the given writers. The ColumnGetters
+// are used to select the columns from a row.
+func New(tw *tabwriter.Writer, cgetters map[string]ColumnGetter, sorted, includeHeader, includeHeaderSeparator bool) *Printer {
+	return &Printer{
+		tw:                     tw,
+		get:                    cgetters,
+		sorted:                 sorted,
+		includeHeader:          includeHeader,
+		includeHeaderSeparator: includeHeaderSeparator,
+	}
+}
+
+// Print writes the rows as a table, selecting on the specified column names.
+func (p *Printer) Print(columns []string, rows []interface{}) error {
+	if err := p.validateColumns(columns); err != nil {
+		return err
+	}
+	if p.includeHeader {
+		if err := p.printHeader(columns); err != nil {
+			return err
+		}
+	}
+	if err := p.printBody(columns, rows); err != nil {
+		return err
+	}
+	return p.tw.Flush()
+}
+
+// validateColumns checks column names for undefined ColumnGetters.
+func (p *Printer) validateColumns(columns []string) error {
+	// Collect unique undefined column names
+	var undefined []string
+	visited := make(map[string]bool)
+	for _, n := range columns {
+		if _, ok := p.get[n]; !ok && !visited[n] {
+			undefined = append(undefined, n)
+			visited[n] = true
+		}
+	}
+
+	if len(undefined) > 0 {
+		var defined []string
+		for g := range p.get {
+			defined = append(defined, g)
+		}
+		sort.Strings(defined)
+		return fmt.Errorf(
+			"undefined column(s) %v: this tableprinter only defines column(s) %v",
+			undefined, defined)
+	}
+	return nil
+}
+
+// printHeader writes a header for the table enumerating the columns.
+func (p *Printer) printHeader(columns []string) error {
+	if _, err := fmt.Fprintln(p.tw, strings.Join(columns, "\t")); err != nil {
+		return fmt.Errorf("failed to write header for columns %v: %v", columns, err)
+	}
+	if !p.includeHeaderSeparator {
+		return nil
+	}
+	separators := make([]string, len(columns))
+	for i, v := range columns {
+		separators[i] = strings.Repeat("-", len(v))
+	}
+	if _, err := fmt.Fprintln(p.tw, strings.Join(separators, "\t")); err != nil {
+		return fmt.Errorf("failed to write header separator for columns %v: %v", columns, err)
+	}
+	return nil
+}
+
+// printBody writes each row by selecting the columns in the given order.
+func (p *Printer) printBody(columns []string, rows []interface{}) error {
+	for _, line := range p.lines(columns, rows) {
+		if _, err := fmt.Fprintln(p.tw, line); err != nil {
+			return fmt.Errorf("failed to write line %q: %v", line, err)
+		}
+	}
+	return nil
+}
+
+func (p *Printer) lines(columns []string, rows []interface{}) []string {
+	// Assemble one line per row
+	var lines []string
+
+	// Holds the selected values: declared outside of loop to avoid reallocation
+	tokens := make([]string, len(columns))
+
+	// Collect lines
+	for _, row := range rows {
+		for c, col := range columns {
+			tokens[c] = p.get[col](row)
+		}
+		lines = append(lines, strings.Join(tokens, "\t"))
+	}
+	if p.sorted {
+		sort.Strings(lines)
+	}
+	return lines
+}

--- a/tableprinter/tableprinter_test.go
+++ b/tableprinter/tableprinter_test.go
@@ -1,0 +1,206 @@
+// Copyright 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tableprinter
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"text/tabwriter"
+)
+
+var (
+	b        = new(bytes.Buffer)
+	tw       = tabwriter.NewWriter(b, 0, 0, 1, ' ', uint(0))
+	cgetters = map[string]ColumnGetter{
+		"service": wrap(service.Name),
+		"host":    wrap(service.Host),
+		"product": wrap(service.ProductName),
+		"version": wrap(service.ProductVersion),
+	}
+)
+
+type service struct {
+	name string
+	host string
+	product
+}
+
+func (s service) Name() string {
+	return s.name
+}
+
+func (s service) Host() string {
+	return s.host
+}
+
+func (s service) ProductName() string {
+	return s.product.name
+}
+
+func (s service) ProductVersion() string {
+	return s.product.version
+}
+
+type product struct {
+	name    string
+	version string
+}
+
+func wrap(getter func(service) string) ColumnGetter {
+	return func(row interface{}) string {
+		return getter(row.(service))
+	}
+}
+
+var tests = []struct {
+	testname      string
+	columns       []string
+	rows          []interface{}
+	includeHeader bool
+	expected      string
+}{
+	{
+		"1 service",
+		[]string{"service", "host", "product", "version"},
+		[]interface{}{
+			service{
+				"foo",
+				"localhost",
+				product{
+					"nvim",
+					"0.1.5",
+				},
+			},
+		},
+		true,
+		"service host      product version\nfoo     localhost nvim    0.1.5\n",
+	},
+	{
+		"2 services sorted by name",
+		[]string{"service", "host", "product", "version"},
+		[]interface{}{
+			service{
+				"bar",
+				"localhost",
+				product{
+					"vim",
+					"7.4",
+				},
+			},
+			service{
+				"foo",
+				"localhost",
+				product{
+					"nvim",
+					"0.1.5",
+				},
+			},
+		},
+		true,
+		"service host      product version\nbar     localhost vim     7.4\nfoo     localhost nvim    0.1.5\n",
+	},
+	{
+		"2 services sorted by product",
+		[]string{"product", "version", "service", "host"},
+		[]interface{}{
+			service{
+				"bar",
+				"localhost",
+				product{
+					"vim",
+					"7.4",
+				},
+			},
+			service{
+				"foo",
+				"localhost",
+				product{
+					"nvim",
+					"0.1.5",
+				},
+			},
+		},
+		true,
+		"product version service host\nnvim    0.1.5   foo     localhost\nvim     7.4     bar     localhost\n",
+	},
+	{
+		"2 services sorted by product with no header",
+		[]string{"product", "version", "service", "host"},
+		[]interface{}{
+			service{
+				"bar",
+				"localhost",
+				product{
+					"vim",
+					"7.4",
+				},
+			},
+			service{
+				"foo",
+				"localhost",
+				product{
+					"nvim",
+					"0.1.5",
+				},
+			},
+		},
+		false,
+		"nvim 0.1.5 foo localhost\nvim  7.4   bar localhost\n",
+	},
+}
+
+func Test(t *testing.T) {
+	for _, e := range tests {
+		check(t, e.testname, e.columns, e.rows, e.includeHeader, e.expected)
+	}
+}
+
+func TestNonexistentColumn(t *testing.T) {
+	b.Truncate(0)
+	p := New(tw, cgetters, true, true, false)
+	dne := "DNE" // this column isn't defined
+	err := p.Print([]string{dne}, nil)
+	switch {
+	case err == nil:
+		t.Fatalf("Print should fail when given a nonexistent column: %q", dne)
+	case !strings.Contains(err.Error(), "undefined column(s)"):
+		t.Fatalf("Print should inform the caller that there are undefined ColumnGetter(s): %v", err.Error())
+	}
+}
+
+func TestErrorDuringWrite(t *testing.T) {
+	b.Truncate(0)
+	p := New(tabwriter.NewWriter(errorWriter{}, 0, 0, 0, ' ', uint(0)), cgetters, true, true, false)
+	err := p.Print([]string{"service"}, nil)
+	switch {
+	case err == nil:
+		t.Errorf("Print should fail when write errors")
+	case !strings.Contains(err.Error(), "failed to write"):
+		t.Fatalf("Print should inform the caller that it failed to write: %v", err.Error())
+	}
+}
+
+func check(t *testing.T, testname string, columns []string, rows []interface{}, includeHeader bool, expected string) {
+	b.Truncate(0)
+	p := New(tw, cgetters, true, includeHeader, false)
+	if err := p.Print(columns, rows); err != nil {
+		t.Fatalf(strings.Join(
+			[]string{"--- test: %s", "--- error: %v"}, "\n",
+		), testname, err)
+	}
+	if b.String() != expected {
+		t.Errorf(strings.Join(
+			[]string{"--- test: %s", "--- columns: %v", "--- rows:%v", "--- found: %q", "--- expected: %q"}, "\n",
+		), testname, columns, rows, b.String(), expected)
+	}
+}
+
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("cannot write")
+}


### PR DESCRIPTION
Differences from internal version:

* Use built-in errors instead of stacktrace
* Add "includeHeaderSeparator" functionality which allows '-' to
  be printed as a separator under headers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/56)
<!-- Reviewable:end -->
