### PR TITLE
Add ContextOptions and add viper implementation

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -13,18 +13,21 @@ import (
 
 type App struct {
 	Command
-	Before       func(ctx Context) error
-	ErrorHandler func(ctx Context, err error) int
-	Version      string
-	Stdout       io.Writer
-	Stderr       io.Writer
-	Completion   map[string]completion.Provider
-	Manpage      *Manpage
-	Backcompat   []Backcompat
-	OnExit       OnExit
+	Before         func(ctx Context) error
+	ErrorHandler   func(ctx Context, err error) int
+	Version        string
+	Stdout         io.Writer
+	Stderr         io.Writer
+	Completion     map[string]completion.Provider
+	Manpage        *Manpage
+	Backcompat     []Backcompat
+	OnExit         OnExit
+	ContextOptions []ContextOption
 }
 
 type Option func(*App)
+
+type ContextOption func(*Context)
 
 func NewApp(opts ...Option) *App {
 	app := &App{

--- a/cli/cliviper/cliviper.go
+++ b/cli/cliviper/cliviper.go
@@ -21,3 +21,11 @@ func (p *flagValueSet) VisitAll(fn func(viper.FlagValue)) {
 		fn((*cli.Context)(p).FlagValue(currFlag.MainName()))
 	}
 }
+
+func App() cli.Option {
+	return func(app *cli.App) {
+		app.ContextOptions = append(app.ContextOptions, func(ctx *cli.Context) {
+			_ = viper.BindFlagValues(FlagValueSet(ctx))
+		})
+	}
+}

--- a/cli/cliviper/cliviper_test.go
+++ b/cli/cliviper/cliviper_test.go
@@ -1,0 +1,37 @@
+// Copyright 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cliviper_test
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/palantir/pkg/cli"
+	"github.com/palantir/pkg/cli/cliviper"
+	"github.com/palantir/pkg/cli/flag"
+)
+
+func TestCLIViperApp(t *testing.T) {
+	var resultVal string
+
+	const msgFlag = "message"
+	const content = "messageContent"
+
+	// set cliviper.App() option
+	app := cli.NewApp(cliviper.App())
+	app.Flags = []flag.Flag{
+		flag.StringFlag{Name: msgFlag},
+	}
+	app.Action = func(ctx cli.Context) error {
+		// all flags for a context should be bound by viper
+		resultVal = viper.GetString(msgFlag)
+		return nil
+	}
+	app.Run([]string{"app", "--message", content})
+
+	assert.Equal(t, content, resultVal)
+}

--- a/cli/gocd_imports.json
+++ b/cli/gocd_imports.json
@@ -14,6 +14,7 @@
             "numImportedGoFiles": 272,
             "importedFrom": [
                 "github.com/palantir/pkg/cli/cliviper",
+                "github.com/palantir/pkg/cli/cliviper_test",
                 "github.com/palantir/pkg/cli_test"
             ]
         },
@@ -33,6 +34,7 @@
             "numGoFiles": 6,
             "numImportedGoFiles": 9,
             "importedFrom": [
+                "github.com/palantir/pkg/cli/cliviper_test",
                 "github.com/palantir/pkg/cli/completion_test",
                 "github.com/palantir/pkg/cli_test"
             ]

--- a/cli/run.go
+++ b/cli/run.go
@@ -146,5 +146,8 @@ func runAction(ctx Context) error {
 		once.Do(onExit)
 	}()
 
+	for _, cfg := range ctx.App.ContextOptions {
+		cfg(&ctx)
+	}
 	return ctx.Command.Action(ctx)
 }


### PR DESCRIPTION
Allows CLI applications to be configured such that actions
automatically bind their flag values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/61)
<!-- Reviewable:end -->
