### PR TITLE
Pass a configurable context.Context along with cli.Context

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -5,6 +5,7 @@
 package cli
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -22,6 +23,7 @@ type App struct {
 	Manpage        *Manpage
 	Backcompat     []Backcompat
 	OnExit         OnExit
+	ContextConfig  func(context.Context) context.Context
 	ContextOptions []ContextOption
 }
 

--- a/cli/context.go
+++ b/cli/context.go
@@ -5,6 +5,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -16,10 +17,16 @@ type Context struct {
 	Path       []string
 	IsTerminal func() bool
 
+	context   context.Context
+	cancel    context.CancelFunc
 	defaults  map[string]interface{}
 	specified map[string]interface{}
 	// stores all flag values in the order they were encountered
 	allVals map[string][]interface{}
+}
+
+func (ctx *Context) Context() context.Context {
+	return ctx.context
 }
 
 func (ctx *Context) Has(name string) bool {

--- a/cli/parse.go
+++ b/cli/parse.go
@@ -5,6 +5,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"syscall"
@@ -25,6 +26,15 @@ func (app *App) parse(args []string) (Context, error) {
 		specified: map[string]interface{}{},
 		allVals:   map[string][]interface{}{},
 	}
+
+	baseContext := context.Background()
+
+	if app.ContextConfig != nil {
+		baseContext = app.ContextConfig(baseContext)
+	}
+
+	ctx.context, ctx.cancel = context.WithCancel(baseContext)
+
 	args = args[1:] // skip name of binary
 	fillDefaults(&ctx)
 	for {

--- a/cli/run.go
+++ b/cli/run.go
@@ -136,6 +136,9 @@ func runAction(ctx Context) error {
 	go func() {
 		if _, ok := <-signals; ok {
 			once.Do(onExit)
+			if ctx.cancel != nil {
+				ctx.cancel()
+			}
 			os.Exit(1)
 		}
 	}()


### PR DESCRIPTION
The basic motivation behind this PR is to add the ability to configure a custom `context.Context` on `cli.App` **once** (such as a complex service logger), and consume that context from anywhere in the cli. Specifically:

- Off of the `cli.App` itself
- Inside of `cli.App.ErrorHandler`
- Inside of `cli.App.Command.Action`
- Inside of `cli.App.Command.Subcommands`

I am aiming for the guarantee that if an app is created normally via `cli.NewApp()`, then a valid (non-`nil`) context is provided in all cases outlined above.

Hopefully this help reduce code duplication in consumer applications, and enable a more straight-forward approach with custom application logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/70)
<!-- Reviewable:end -->
