### PR TITLE
Special case safeyaml's Unmarshal for map keys

### DIFF
--- a/safeyaml/unmarshal.go
+++ b/safeyaml/unmarshal.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-2016 Michael Persson
+// Copyright (c) 2012–2015 Elasticsearch <http://www.elastic.co>
+//
+// The bulk of this code is copied from from https://github.com/go-yaml/yaml/issues/139#issuecomment-220072190
+//
+// Originally distributed as part of "beats" repository (https://github.com/elastic/beats).
+// Modified specifically for "iodatafmt" package.
+//
+// Distributed underneath "Apache License, Version 2.0" which is compatible with the LICENSE for this package.
+
+package safeyaml
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Unmarshal YAML to map[string]interface{} instead of map[interface{}]interface{}.
+func Unmarshal(in []byte, out interface{}) error {
+	var res interface{}
+
+	if err := yaml.Unmarshal(in, &res); err != nil {
+		return err
+	}
+	*out.(*interface{}) = cleanupMapValue(res)
+
+	return nil
+}
+
+func cleanupInterfaceArray(in []interface{}) []interface{} {
+	res := make([]interface{}, len(in))
+	for i, v := range in {
+		res[i] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for k, v := range in {
+		res[fmt.Sprintf("%v", k)] = cleanupMapValue(v)
+	}
+	return res
+}
+
+func cleanupMapValue(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanupInterfaceArray(v)
+	case map[interface{}]interface{}:
+		return cleanupInterfaceMap(v)
+	default:
+		return v
+	}
+}

--- a/safeyaml/unmarshal_test.go
+++ b/safeyaml/unmarshal_test.go
@@ -1,0 +1,48 @@
+// Copyright 2016 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package safeyaml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var data = `top-level:
+  unquoted_0: unquoted
+  "quoted_0": unquoted
+  unquoted_1: "quoted"
+  quoted_1: "quoted"
+  int: 0
+  bool: true`
+
+func TestUnmarshal(t *testing.T) {
+	for _, testcase := range []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		{
+			name:  "test unmarshal",
+			input: data,
+			expected: map[string]interface{}{
+				"top-level": map[string]interface{}{
+					"unquoted_0": "unquoted",
+					"quoted_0":   "unquoted",
+					"unquoted_1": "quoted",
+					"quoted_1":   "quoted",
+					"int":        0,
+					"bool":       true,
+				},
+			},
+		},
+	} {
+		var got interface{}
+		err := Unmarshal([]byte(testcase.input), &got)
+		if assert.NoError(t, err, testcase.name) {
+			assert.Equal(t, testcase.expected, got, testcase.name)
+		}
+	}
+}

--- a/safeyaml/unmarshal_test.go
+++ b/safeyaml/unmarshal_test.go
@@ -23,6 +23,7 @@ func TestUnmarshal(t *testing.T) {
 		name     string
 		input    string
 		expected interface{}
+		errMsg   string
 	}{
 		{
 			name:  "test unmarshal",
@@ -38,11 +39,24 @@ func TestUnmarshal(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "conflicting keys",
+			input: `top-level:
+  "5": ""
+  5: ""`,
+			errMsg: "conflicting key",
+		},
 	} {
 		var got interface{}
 		err := Unmarshal([]byte(testcase.input), &got)
-		if assert.NoError(t, err, testcase.name) {
-			assert.Equal(t, testcase.expected, got, testcase.name)
+		if testcase.errMsg == "" {
+			if assert.NoError(t, err, testcase.name) {
+				assert.Equal(t, testcase.expected, got, testcase.name)
+			}
+		} else {
+			if assert.Error(t, err, testcase.name) {
+				assert.Contains(t, err.Error(), testcase.errMsg, testcase.name)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Unmarshal maps in safeyaml to `map[string]interface{}` instead of
`map[interface{}]interface{}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/73)
<!-- Reviewable:end -->
