### PR TITLE
tlsconfig: Explicitly disable client renegotiation

### DIFF
--- a/tlsconfig/common.go
+++ b/tlsconfig/common.go
@@ -82,6 +82,7 @@ func configureTLSConfig(cfgs ...configurer) (*tls.Config, error) {
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		CipherSuites:             defaultCipherSuites,
+		Renegotiation:            tls.RenegotiateNever,
 	}
 	for _, currCfg := range cfgs {
 		if err := currCfg(tlsCfg); err != nil {


### PR DESCRIPTION
Explicitly disable TLS client renegotiation per internal guidelines.