### PR TITLE
Add default version variable

### DIFF
--- a/cobracli/default.go
+++ b/cobracli/default.go
@@ -9,9 +9,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ExecuteWithDefaultParams executes the provided root command using the parameters returned by DefaultParams. Typical
-// usage is "os.Exit(cobracli.ExecuteWithDefaultParams(...))" in a main function.
-func ExecuteWithDefaultParams(rootCmd *cobra.Command, debugVar *bool, version string) int {
+var version = "unspecified"
+
+// ExecuteWithDefaultParams executes the provided root command using the parameters returned by DefaultParams. This
+// function also adds a "version command that prints the value of the "version" variable of this package. The value of
+// this version variable should be set using build flags. Typical usage is
+// "os.Exit(cobracli.ExecuteWithDefaultParams(...))" in a main function.
+func ExecuteWithDefaultParams(rootCmd *cobra.Command, debugVar *bool) int {
+	return ExecuteWithDefaultParamsWithVersion(rootCmd, debugVar, version)
+}
+
+// ExecuteWithDefaultParamsWithVersion executes the provided root command using the parameters returned by
+// DefaultParams. Typical usage is "os.Exit(cobracli.ExecuteWithDefaultParamsWithVersion(...))" in a main function.
+func ExecuteWithDefaultParamsWithVersion(rootCmd *cobra.Command, debugVar *bool, version string) int {
 	return Execute(rootCmd, DefaultParams(debugVar, version)...)
 }
 

--- a/cobracli/default_test.go
+++ b/cobracli/default_test.go
@@ -152,7 +152,7 @@ func TestExecuteWithDefaultParams(t *testing.T) {
 				tc.configure(rootCmd)
 			}
 
-			rv := cobracli.ExecuteWithDefaultParams(rootCmd, tc.debugVar, tc.version)
+			rv := cobracli.ExecuteWithDefaultParamsWithVersion(rootCmd, tc.debugVar, tc.version)
 			require.Equal(t, tc.wantRV, rv, "Case %d: %s", i, tc.name)
 
 			switch val := tc.wantOutput.(type) {


### PR DESCRIPTION
Update "ExecuteWithDefaultParams" function to use the new default
version variable and add a new "ExecuteWithDefaultParamsWithVersion"
function that allows version variable to be specified explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/83)
<!-- Reviewable:end -->
