### PR TITLE
Cross-platform compatibility.

### DIFF
--- a/cli/exitcode_test.go
+++ b/cli/exitcode_test.go
@@ -9,7 +9,8 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
+	"runtime"
 	"syscall"
 	"testing"
 
@@ -66,14 +67,18 @@ func runGoFile(t *testing.T, src string) ([]byte, error) {
 		}
 	}()
 
-	err = ioutil.WriteFile(path.Join(tmpDir, "test_cli.go"), []byte(src), 0644)
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "test_cli.go"), []byte(src), 0644)
 	require.NoError(t, err)
 
-	buildCmd := exec.Command("go", "build", "-o", "test-cli", ".")
+	binName := "test-cli"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	buildCmd := exec.Command("go", "build", "-o", binName, ".")
 	buildCmd.Dir = tmpDir
 	output, err := buildCmd.CombinedOutput()
 	require.NoError(t, err, "%v failed: %s", buildCmd.Args, string(output))
 
-	testCLICmd := exec.Command(path.Join(tmpDir, "test-cli"))
+	testCLICmd := exec.Command(filepath.Join(tmpDir, binName))
 	return testCLICmd.CombinedOutput()
 }

--- a/matcher/files_test.go
+++ b/matcher/files_test.go
@@ -7,7 +7,7 @@ package matcher_test
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/nmiyake/pkg/dirs"
@@ -67,6 +67,10 @@ func TestListFiles(t *testing.T) {
 		got, err := matcher.ListFiles(currCaseTmpDir, currCase.include, currCase.exclude)
 		require.NoError(t, err, "Case %d", i)
 
+		for i, want := range currCase.want {
+			currCase.want[i] = filepath.FromSlash(want)
+		}
+
 		assert.Equal(t, currCase.want, got, "Case %d", i)
 	}
 }
@@ -76,10 +80,10 @@ func createFiles(t *testing.T, tmpDir string, files map[string]string) string {
 	require.NoError(t, err)
 
 	for currFile, currContent := range files {
-		err := os.MkdirAll(path.Join(currCaseTmpDir, path.Dir(currFile)), 0755)
+		err := os.MkdirAll(filepath.Join(currCaseTmpDir, filepath.Dir(currFile)), 0755)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(path.Join(currCaseTmpDir, currFile), []byte(currContent), 0644)
+		err = ioutil.WriteFile(filepath.Join(currCaseTmpDir, currFile), []byte(currContent), 0644)
 		require.NoError(t, err)
 	}
 

--- a/osutil/osutil.go
+++ b/osutil/osutil.go
@@ -1,0 +1,30 @@
+package osutil
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// MakeValidRegexPath takes a path and makes it into a valid regex string
+func MakeValidRegexPath(path string) string {
+	return strings.Replace(filepath.FromSlash(path), "\\", "\\\\", -1)
+}
+
+// GetNotADirErrorMsg returns the error message given if an action is
+// performed on a non-existant directory.
+func GetNotADirErrorMsg() string {
+	if runtime.GOOS == "windows" {
+		return "The system cannot find the path specified."
+	}
+	return "not a directory"
+}
+
+// GetNoSuchFileOrDirErrorMsg returns the error message given if an action is
+// performed on a non-existant file or directory.
+func GetNoSuchFileOrDirErrorMsg() string {
+	if runtime.GOOS == "windows" {
+		return "The system cannot find the file specified."
+	}
+	return "no such file or directory"
+}

--- a/osutil/osutil_test.go
+++ b/osutil/osutil_test.go
@@ -1,0 +1,25 @@
+package osutil_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/palantir/pkg/osutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidRegexPath(t *testing.T) {
+	currentAbs, err := filepath.Abs(".")
+	require.NoError(t, err)
+
+	fmtString := `here is a path: %s with some text after`
+	myRegexDef := fmt.Sprintf(
+		"^"+fmtString+"$",
+		osutil.MakeValidRegexPath(currentAbs),
+	)
+
+	assert.Regexp(t, regexp.MustCompile(myRegexDef), fmt.Sprintf(fmtString, currentAbs))
+}

--- a/signals/signals_test.go
+++ b/signals/signals_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -20,6 +21,9 @@ import (
 )
 
 func TestCancelOnSignalsContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		return
+	}
 	ctx, _ := signals.CancelOnSignalsContext(context.Background(), syscall.SIGHUP)
 
 	sendSignalToCurrProcess(t, syscall.SIGHUP)
@@ -35,6 +39,10 @@ func TestCancelOnSignalsContext(t *testing.T) {
 }
 
 func TestRegisterStackTraceWriterOnSignals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+
 	out := &bytes.Buffer{}
 	signals.RegisterStackTraceWriterOnSignals(out, nil, syscall.SIGHUP)
 
@@ -51,6 +59,10 @@ func (w errWriter) Write(p []byte) (n int, err error) {
 }
 
 func TestRegisterStackTraceWriterErrorHandler(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+
 	out := errWriter{}
 	var handlerErr error
 	errHandler := func(err error) {
@@ -72,6 +84,10 @@ func TestRegisterStackTraceWriterErrorHandler(t *testing.T) {
 }
 
 func TestUnregisterStackTraceWriterOnSignals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+
 	out := &bytes.Buffer{}
 	unregister := signals.RegisterStackTraceWriterOnSignals(out, nil, syscall.SIGHUP)
 	unregister()
@@ -83,6 +99,10 @@ func TestUnregisterStackTraceWriterOnSignals(t *testing.T) {
 }
 
 func TestNewSignalReceiver(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+
 	c := signals.NewSignalReceiver(syscall.SIGHUP)
 
 	sendSignalToCurrProcess(t, syscall.SIGHUP)

--- a/specdir/node.go
+++ b/specdir/node.go
@@ -7,7 +7,7 @@ package specdir
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 )
 
@@ -71,7 +71,7 @@ func (n *fileNode) fileNode() *fileNode {
 
 func (n *fileNode) createDirectoryStructure(parentDir string, values TemplateValues, includeOptional bool) error {
 	if n.pathType == DirPath && (!n.optional || includeOptional) {
-		currPath := path.Join(parentDir, n.name.name(values))
+		currPath := filepath.Join(parentDir, n.name.name(values))
 		if err := os.MkdirAll(currPath, 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %v", currPath, err)
 		}
@@ -93,7 +93,7 @@ func (p fileNodePath) getPath(templateValues map[string]string) string {
 	for _, node := range p {
 		parts = append(parts, node.name.name(templateValues))
 	}
-	return path.Join(parts...)
+	return filepath.Join(parts...)
 }
 
 // getTemplateNames returns the names of all of the templates in the given path
@@ -110,7 +110,7 @@ func (n *fileNode) paths(parentPath string, templateValues map[string]string, in
 
 	// only add node and children if it is not optional or if optional paths are being included
 	if !n.optional || includeOptional {
-		currPath := path.Join(parentPath, n.name.name(templateValues))
+		currPath := filepath.Join(parentPath, n.name.name(templateValues))
 
 		// add current node
 		paths = append(paths, currPath)
@@ -174,7 +174,7 @@ func (n *fileNode) validate(rootDir, pathFromRoot string, values TemplateValues)
 func (n *fileNode) verifyLayoutForDir(rootDir, pathFromRoot string, values TemplateValues) error {
 	if n.pathType == DirPath {
 		for _, c := range n.children {
-			currPath := path.Join(pathFromRoot, c.fileNode().name.name(values))
+			currPath := filepath.Join(pathFromRoot, c.fileNode().name.name(values))
 			if err := c.fileNode().validate(rootDir, currPath, values); err != nil {
 				return err
 			}

--- a/specdir/spec.go
+++ b/specdir/spec.go
@@ -7,7 +7,7 @@ package specdir
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 type PathType bool
@@ -170,22 +170,23 @@ func getTemplateKeysFromName(n NodeName) []string {
 }
 
 func verifyPath(rootDirPath, pathFromRootDir, expectedName string, pathType PathType, optional bool) error {
-	if path.Base(pathFromRootDir) != expectedName {
+	if filepath.Base(pathFromRootDir) != expectedName {
 		return fmt.Errorf("%s is not a path to %s", pathFromRootDir, expectedName)
 	}
 
-	pathInfo, err := os.Stat(path.Join(rootDirPath, pathFromRootDir))
+	pathInfo, err := os.Stat(filepath.Join(rootDirPath, pathFromRootDir))
 	if err != nil {
 		if os.IsNotExist(err) {
 			if !optional {
-				return fmt.Errorf("%s does not exist", path.Join(path.Base(rootDirPath), pathFromRootDir))
+				return fmt.Errorf("%s does not exist", filepath.Join(filepath.Base(rootDirPath), pathFromRootDir))
 			}
 			// path does not exist, but it is optional so is okay
 			return nil
 		}
-		return fmt.Errorf("failed to stat %s", path.Join(path.Base(rootDirPath), pathFromRootDir))
+		return fmt.Errorf("failed to stat %s", filepath.Join(filepath.Base(rootDirPath), pathFromRootDir))
 	} else if currIsDir := pathInfo.IsDir(); currIsDir == bool(pathType) {
-		return fmt.Errorf("isDir for %s returned wrong value: expected %v, was %v", path.Join(path.Base(rootDirPath), pathFromRootDir), !pathType, currIsDir)
+		return fmt.Errorf("isDir for %s returned wrong value: expected %v, was %v",
+			filepath.Join(filepath.Base(rootDirPath), pathFromRootDir), !pathType, currIsDir)
 	}
 
 	return nil

--- a/specdir/specdir.go
+++ b/specdir/specdir.go
@@ -7,7 +7,7 @@ package specdir
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 )
 
@@ -42,9 +42,9 @@ func (s *specDirStruct) Path(name string) string {
 	if value, ok := s.aliasValues[name]; ok {
 		pathRoot := s.rootDir
 		if s.spec.rootIsPartOfSpec() {
-			pathRoot = path.Dir(s.rootDir)
+			pathRoot = filepath.Dir(s.rootDir)
 		}
-		return path.Join(pathRoot, value)
+		return filepath.Join(pathRoot, value)
 	}
 	return ""
 }
@@ -78,7 +78,7 @@ func New(rootDir string, spec LayoutSpec, values TemplateValues, mode Mode) (Spe
 		// if the root directory is part of the specification, verify that the name matches the required name
 		if spec.rootIsPartOfSpec() {
 			expectedRootDirName := spec.rootNode().name.name(values)
-			if path.Base(rootDir) != expectedRootDirName {
+			if filepath.Base(rootDir) != expectedRootDirName {
 				return nil, fmt.Errorf("root directory name %s does not match name required by specification: %v", rootDir, expectedRootDirName)
 			}
 		}

--- a/specdir/specdir_test.go
+++ b/specdir/specdir_test.go
@@ -5,11 +5,14 @@
 package specdir_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
+
+	"github.com/palantir/pkg/osutil"
 
 	"github.com/nmiyake/pkg/dirs"
 	"github.com/stretchr/testify/assert"
@@ -39,13 +42,13 @@ func TestSpecDirConstruction(t *testing.T) {
 		{
 			rootDir:       "missing",
 			spec:          specdir.NewLayoutSpec(specdir.Dir(specdir.LiteralName("root"), ""), true),
-			expectedError: `^.+/missing is not a path to root$`,
+			expectedError: fmt.Sprintf(`^.+%s is not a path to root$`, osutil.MakeValidRegexPath("/missing")),
 		},
 	} {
 		currCaseTmpDir, err := ioutil.TempDir(tmpDir, "")
 		require.NoError(t, err)
 
-		rootForCreation := path.Join(currCaseTmpDir, currCase.rootDir)
+		rootForCreation := filepath.Join(currCaseTmpDir, currCase.rootDir)
 		err = os.Mkdir(rootForCreation, 0755)
 		require.NoError(t, err)
 
@@ -69,7 +72,7 @@ func TestSpecDirCreateMode(t *testing.T) {
 		specdir.Dir(specdir.LiteralName("root"), "",
 			specdir.Dir(specdir.LiteralName("child"), ""),
 		), true)
-	rootForCreation := path.Join(tmpDir, "root")
+	rootForCreation := filepath.Join(tmpDir, "root")
 	_, err = specdir.New(rootForCreation, spec, nil, specdir.Create)
 	require.NoError(t, err)
 
@@ -118,7 +121,7 @@ func TestSpecDirGetPath(t *testing.T) {
 		currCaseTmpDir, err := ioutil.TempDir(tmpDir, "")
 		require.NoError(t, err)
 
-		rootForCreation := path.Join(currCaseTmpDir, currCase.rootDir)
+		rootForCreation := filepath.Join(currCaseTmpDir, currCase.rootDir)
 		err = os.Mkdir(rootForCreation, 0755)
 		require.NoError(t, err)
 
@@ -129,6 +132,6 @@ func TestSpecDirGetPath(t *testing.T) {
 
 		actualPath := specDir.Path("VeryInnerDir")
 
-		assert.Equal(t, path.Join(currCaseTmpDir, currCase.expectedPath), actualPath, "Case %d", i)
+		assert.Equal(t, filepath.Join(currCaseTmpDir, currCase.expectedPath), actualPath, "Case %d", i)
 	}
 }

--- a/tlsconfig/tlsconfig_client_test.go
+++ b/tlsconfig/tlsconfig_client_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/palantir/pkg/osutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -57,12 +58,12 @@ func TestNewClientConfigErrors(t *testing.T) {
 		{
 			name:      "missing certificate file",
 			keyFile:   clientKeyFile,
-			wantError: "failed to load TLS certificate: open : no such file or directory",
+			wantError: "failed to load TLS certificate: open : " + osutil.GetNoSuchFileOrDirErrorMsg(),
 		},
 		{
 			name:      "missing key file",
 			certFile:  clientCertFile,
-			wantError: "failed to load TLS certificate: open : no such file or directory",
+			wantError: "failed to load TLS certificate: open : " + osutil.GetNoSuchFileOrDirErrorMsg(),
 		},
 		{
 			name:     "invalid CA file",


### PR DESCRIPTION
Changed uses of `"path"` to `"path/filepath"`, in order to make the logic cross-platform compatible.

Added a little bit of extra logic in certain functions of `matchers` and `pkgpath`, which makes them work on Windows systems too.

Finally, the tests that are currently failing on Windows have been fixed. To help this, I've added a small extra package `osutil`, which contains some reusable code-snippets.

Ran all tests on an Unix system, and they still pass.