### PR TITLE
matcher: fix handling of parent directories ("..")

### DIFF
--- a/matcher/matchers_test.go
+++ b/matcher/matchers_test.go
@@ -59,6 +59,8 @@ func TestPathMatcher(t *testing.T) {
 	}{
 		{[]string{"foo"}, "foo/bar/regular", true},
 		{[]string{"foo"}, "bar/foo/inner", false},
+		{[]string{"foo"}, "../foo/bar/foo/inner", false},
+		{[]string{"../foo"}, "../foo/bar/foo/inner", true},
 		// full match required
 		{[]string{"foo"}, "fooLongerName/inner", false},
 		// glob matching
@@ -109,6 +111,7 @@ func TestHiddenMatcher(t *testing.T) {
 		want bool
 	}{
 		{"foo/bar/regular", false},
+		{"../foo/bar/regular", false},
 		{"foo/bar/.hidden", true},
 		{"foo/.bar/inHidden", true},
 		{"foo/.bar/inHidden", true},


### PR DESCRIPTION
Update name matcher to ignore ".." path components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/88)
<!-- Reviewable:end -->
