### PR TITLE
Remove unused metrics from the metrics pkg

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -16,18 +16,23 @@ import (
 
 var (
 	goRuntimeMetricsToExclude = map[string]struct{}{
-		"go.runtime.MemStats.BuckHashSys": {},
-		"go.runtime.MemStats.DebugGC":     {},
-		"go.runtime.MemStats.EnableGC":    {},
-		"go.runtime.MemStats.NextGC":      {},
-		"go.runtime.MemStats.LastGC":      {},
-		"go.runtime.MemStats.Lookups":     {},
-		"go.runtime.MemStats.TotalAlloc":  {}, // TotalAlloc increases as heap objects are allocated, but unlike Alloc and HeapAlloc, it does not decrease when objects are freed
-		"go.runtime.MemStats.MCacheInuse": {},
-		"go.runtime.MemStats.MCacheSys":   {},
-		"go.runtime.MemStats.MSpanInuse":  {},
-		"go.runtime.MemStats.MSpanSys":    {},
-		"go.runtime.MemStats.Sys":         {},
+		"go.runtime.MemStats.BuckHashSys":  {},
+		"go.runtime.MemStats.DebugGC":      {},
+		"go.runtime.MemStats.EnableGC":     {},
+		"go.runtime.MemStats.NextGC":       {},
+		"go.runtime.MemStats.LastGC":       {},
+		"go.runtime.MemStats.Lookups":      {},
+		"go.runtime.MemStats.TotalAlloc":   {}, // TotalAlloc increases as heap objects are allocated, but unlike Alloc and HeapAlloc, it does not decrease when objects are freed
+		"go.runtime.MemStats.MCacheInuse":  {},
+		"go.runtime.MemStats.MCacheSys":    {},
+		"go.runtime.MemStats.MSpanInuse":   {},
+		"go.runtime.MemStats.MSpanSys":     {},
+		"go.runtime.MemStats.Sys":          {},
+		"go.runtime.MemStats.Frees":        {},
+		"go.runtime.MemStats.Mallocs":      {},
+		"go.runtime.MemStats.StackSys":     {},
+		"go.runtime.NumCgoCall":            {},
+		"go.runtime.MemStats.PauseTotalNs": {},
 	}
 
 	_ Registry = &NoopRegistry{}

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -118,7 +118,6 @@ func TestRegistryRegistrationWithMemStats(t *testing.T) {
 
 	wantNames := []string{
 		"go.runtime.MemStats.Alloc",
-		"go.runtime.MemStats.Frees",
 		"go.runtime.MemStats.GCCPUFraction",
 		"go.runtime.MemStats.HeapAlloc",
 		"go.runtime.MemStats.HeapIdle",
@@ -126,13 +125,9 @@ func TestRegistryRegistrationWithMemStats(t *testing.T) {
 		"go.runtime.MemStats.HeapObjects",
 		"go.runtime.MemStats.HeapReleased",
 		"go.runtime.MemStats.HeapSys",
-		"go.runtime.MemStats.Mallocs",
 		"go.runtime.MemStats.NumGC",
 		"go.runtime.MemStats.PauseNs",
-		"go.runtime.MemStats.PauseTotalNs",
 		"go.runtime.MemStats.StackInuse",
-		"go.runtime.MemStats.StackSys",
-		"go.runtime.NumCgoCall",
 		"go.runtime.NumGoroutine",
 		"go.runtime.NumThread",
 		"go.runtime.ReadMemStats",


### PR DESCRIPTION
Adding metrics that we know are never actually read, even though they are emitted

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/114)
<!-- Reviewable:end -->
