### PR TITLE
🚀 Speed up toMetricTagsID

### DIFF
--- a/metrics/benchmark_test.go
+++ b/metrics/benchmark_test.go
@@ -1,0 +1,25 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+)
+
+func BenchmarkRegisterMetric(b *testing.B)  {
+	ctx := AddTags(WithRegistry(context.Background(), NewRootMetricsRegistry()),
+		MustNewTag("key1", "val1"),
+		MustNewTag("key2", "val2"),
+		MustNewTag("key3", "val3"),
+		MustNewTag("key4", "val4"),
+		MustNewTag("key5", "val5"),
+		MustNewTag("key6", "val6"),
+		MustNewTag("key7", "val7"),
+		MustNewTag("key8", "val8"),
+		)
+	b.ResetTimer()
+	b.ReportAllocs()
+	reg := FromContext(ctx)
+	for i := 0; i < b.N; i++ {
+		reg.Counter("metricName").Inc(1)
+	}
+}

--- a/metrics/benchmark_test.go
+++ b/metrics/benchmark_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package metrics
 
 import (
@@ -6,7 +10,7 @@ import (
 	"testing"
 )
 
-func BenchmarkRegisterMetric(b *testing.B)  {
+func BenchmarkRegisterMetric(b *testing.B) {
 	b.Run("1 tag", func(b *testing.B) {
 		doBench(b, 1)
 	})

--- a/metrics/benchmark_test.go
+++ b/metrics/benchmark_test.go
@@ -2,20 +2,28 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
 
 func BenchmarkRegisterMetric(b *testing.B)  {
-	ctx := AddTags(WithRegistry(context.Background(), NewRootMetricsRegistry()),
-		MustNewTag("key1", "val1"),
-		MustNewTag("key2", "val2"),
-		MustNewTag("key3", "val3"),
-		MustNewTag("key4", "val4"),
-		MustNewTag("key5", "val5"),
-		MustNewTag("key6", "val6"),
-		MustNewTag("key7", "val7"),
-		MustNewTag("key8", "val8"),
-		)
+	b.Run("1 tag", func(b *testing.B) {
+		doBench(b, 1)
+	})
+	b.Run("10 tag", func(b *testing.B) {
+		doBench(b, 10)
+	})
+	b.Run("100 tag", func(b *testing.B) {
+		doBench(b, 100)
+	})
+}
+
+func doBench(b *testing.B, n int) {
+	var tags Tags
+	for i := 0; i < n; i++ {
+		tags = append(tags, MustNewTag(fmt.Sprintf("key%d", i), fmt.Sprintf("val%d", i)))
+	}
+	ctx := AddTags(WithRegistry(context.Background(), NewRootMetricsRegistry()), tags...)
 	b.ResetTimer()
 	b.ReportAllocs()
 	reg := FromContext(ctx)

--- a/metrics/tag.go
+++ b/metrics/tag.go
@@ -103,14 +103,16 @@ func NewTag(k, v string) (Tag, error) {
 		return Tag{}, errors.New(`full tag ("key:value") must be <= 200 characters`)
 	}
 
-	return newTag(normalizeTag(k), normalizeTag(v)), nil
+	return newTag(k, v), nil
 }
 
-func newTag(normalizedKey, normakizedValue string) Tag {
+func newTag(k, v string) Tag {
+	normalizedKey := normalizeTag(k)
+	normalizedValue := normalizeTag(v)
 	return Tag{
 		key:      normalizedKey,
-		value:    normakizedValue,
-		keyValue: normalizedKey + ":" + normakizedValue,
+		value:    normalizedValue,
+		keyValue: normalizedKey + ":" + normalizedValue,
 	}
 }
 

--- a/metrics/tag.go
+++ b/metrics/tag.go
@@ -103,13 +103,15 @@ func NewTag(k, v string) (Tag, error) {
 		return Tag{}, errors.New(`full tag ("key:value") must be <= 200 characters`)
 	}
 
-	tag := Tag{
-		key:   normalizeTag(k),
-		value: normalizeTag(v),
-	}
-	tag.keyValue = tag.key + ":" + tag.value
+	return newTag(normalizeTag(k), normalizeTag(v)), nil
+}
 
-	return tag, nil
+func newTag(normalizedKey, normakizedValue string) Tag {
+	return Tag{
+		key:      normalizedKey,
+		value:    normakizedValue,
+		keyValue: normalizedKey + ":" + normakizedValue,
+	}
 }
 
 // MustNewTags returns the result of calling NewTags, but panics if NewTags returns an error. Should only be used in


### PR DESCRIPTION
`toMetricTagsID` is called every time a metric is incremented/changed. This PR updates the implementation to run faster and allocate less memory.

Benchmark results:
Old
```
goos: darwin
goarch: amd64
pkg: github.com/palantir/pkg/metrics
BenchmarkRegisterMetric/1_tag-8          2000000     908 ns/op     800 B/op   10 allocs/op
BenchmarkRegisterMetric/10_tag-8          300000    4905 ns/op    2910 B/op   27 allocs/op
BenchmarkRegisterMetric/100_tag-8          30000   53716 ns/op   30639 B/op  136 allocs/op
PASS
ok  	github.com/palantir/pkg/metrics	6.802s
```
New
```
goos: darwin
goarch: amd64
pkg: github.com/palantir/pkg/metrics
BenchmarkRegisterMetric/1_tag-8          5000000     300 ns/op     208 B/op    4 allocs/op
BenchmarkRegisterMetric/10_tag-8         2000000     657 ns/op     368 B/op    4 allocs/op
BenchmarkRegisterMetric/100_tag-8         200000    8304 ns/op    2704 B/op    4 allocs/op
PASS
ok  	github.com/palantir/pkg/metrics	5.880s
```

This was flagged by an internal team looking at the pprofs of their service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/130)
<!-- Reviewable:end -->
