### PR TITLE
Add binary package for base64 encoding

### DIFF
--- a/binary/binary.go
+++ b/binary/binary.go
@@ -8,24 +8,25 @@ import (
 	"encoding/base64"
 )
 
-var encoding = base64.StdEncoding
+var b64 = base64.StdEncoding
 
 // Binary wraps binary data and provides encoding helpers using base64.StdEncoding.
 // Use this type for binary fields serialized/deserialized as base64 text.
-// We store then encoded string instead of an aliased []byte so this type can be used as a map key.
+// Type is specified as string rather than []byte so that it can be used as a map key.
 // Use Bytes() to access the raw bytes.
+// Values of this type are only valid when the backing string is Base64-encoded using standard encoding.
 type Binary string
 
 func New(data []byte) Binary {
-	return Binary(encoding.EncodeToString(data))
+	return Binary(b64.EncodeToString(data))
 }
 
 func (b Binary) Bytes() ([]byte, error) {
-	return encoding.DecodeString(string(b))
+	return b64.DecodeString(string(b))
 }
 
 func (b Binary) MarshalText() (text []byte, err error) {
-	// Test that we can decode data before returning invalid base64
+	// Verify that data is base64-encoded
 	if _, err := b.Bytes(); err != nil {
 		return nil, err
 	}
@@ -34,8 +35,8 @@ func (b Binary) MarshalText() (text []byte, err error) {
 }
 
 func (b *Binary) UnmarshalText(data []byte) error {
-	// Test that we can decode data before storing invalid base64
-	if _, err := b.Bytes(); err != nil {
+	// Verify that data is base64-encoded
+	if _, err := Binary(data).Bytes(); err != nil {
 		return err
 	}
 

--- a/binary/binary.go
+++ b/binary/binary.go
@@ -20,14 +20,22 @@ func New(data []byte) Binary {
 	return Binary(encoding.EncodeToString(data))
 }
 
-func (b *Binary) Bytes() ([]byte, error) {
-	return encoding.DecodeString(string(*b))
+func (b Binary) Bytes() ([]byte, error) {
+	return encoding.DecodeString(string(b))
+}
+
+func (b Binary) MarshalText() (text []byte, err error) {
+	// Test that we can decode data before returning invalid base64
+	if _, err := b.Bytes(); err != nil {
+		return nil, err
+	}
+
+	return []byte(b), nil
 }
 
 func (b *Binary) UnmarshalText(data []byte) error {
-	// Test that we can decode data
-	decoded := make([]byte, encoding.DecodedLen(len(data)))
-	if _, err := encoding.Decode(decoded, data); err != nil {
+	// Test that we can decode data before storing invalid base64
+	if _, err := b.Bytes(); err != nil {
 		return err
 	}
 

--- a/binary/binary.go
+++ b/binary/binary.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package binary
+
+import (
+	"encoding/base64"
+)
+
+// Binary wraps a []byte and provides MarshalText/UnmarshalText encoding helpers using base64.StdEncoding.
+type Binary []byte
+
+var encoding = base64.StdEncoding
+
+func (b Binary) MarshalText() ([]byte, error) {
+	encoded := make([]byte, encoding.EncodedLen(len(b)))
+	encoding.Encode(encoded, b)
+	return encoded, nil
+}
+
+func (b *Binary) UnmarshalText(data []byte) error {
+	decoded := make([]byte, encoding.DecodedLen(len(data)))
+	n, err := encoding.Decode(decoded, data)
+	if err != nil {
+		return err
+	}
+	*b = Binary(decoded[:n])
+	return nil
+}

--- a/binary/binary.go
+++ b/binary/binary.go
@@ -8,14 +8,25 @@ import (
 	"encoding/base64"
 )
 
-// Binary wraps a []byte and provides MarshalText/UnmarshalText encoding helpers using base64.StdEncoding.
-type Binary []byte
+// Binary wraps binary data and provides MarshalText/UnmarshalText encoding helpers using base64.StdEncoding.
+// We use a struct instead of an aliased []byte so this type can be used as a map key.
+type Binary struct {
+	Data []byte
+}
+
+func New(data []byte) Binary {
+	return Binary{Data: data}
+}
 
 var encoding = base64.StdEncoding
 
+func (b Binary) String() string {
+	return encoding.EncodeToString(b.Data)
+}
+
 func (b Binary) MarshalText() ([]byte, error) {
-	encoded := make([]byte, encoding.EncodedLen(len(b)))
-	encoding.Encode(encoded, b)
+	encoded := make([]byte, encoding.EncodedLen(len(b.Data)))
+	encoding.Encode(encoded, b.Data)
 	return encoded, nil
 }
 
@@ -25,6 +36,6 @@ func (b *Binary) UnmarshalText(data []byte) error {
 	if err != nil {
 		return err
 	}
-	*b = Binary(decoded[:n])
+	b.Data = decoded[:n]
 	return nil
 }

--- a/binary/binary_test.go
+++ b/binary/binary_test.go
@@ -25,7 +25,7 @@ func TestBinary_MarshalText(t *testing.T) {
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			out, err := binary.Binary(test.Input).MarshalText()
+			out, err := binary.New(test.Input).MarshalText()
 			assert.NoError(t, err)
 			assert.Equal(t, string(test.Output), string(out))
 		})
@@ -48,7 +48,7 @@ func TestBinary_UnmarshalText(t *testing.T) {
 			var bin binary.Binary
 			err := bin.UnmarshalText(test.Input)
 			assert.NoError(t, err)
-			assert.Equal(t, string(test.Output), string(bin))
+			assert.Equal(t, string(test.Output), string(bin.Data))
 		})
 	}
 }

--- a/binary/binary_test.go
+++ b/binary/binary_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package binary_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/palantir/pkg/binary"
+)
+
+func TestBinary_MarshalText(t *testing.T) {
+	for _, test := range []struct {
+		Name   string
+		Input  []byte
+		Output []byte
+	}{
+		{
+			Name:   "hello world",
+			Input:  []byte(`hello world`),
+			Output: []byte(`aGVsbG8gd29ybGQ=`),
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			out, err := binary.Binary(test.Input).MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, string(test.Output), string(out))
+		})
+	}
+}
+
+func TestBinary_UnmarshalText(t *testing.T) {
+	for _, test := range []struct {
+		Name   string
+		Input  []byte
+		Output []byte
+	}{
+		{
+			Name:   "hello world",
+			Input:  []byte(`aGVsbG8gd29ybGQ=`),
+			Output: []byte(`hello world`),
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			var bin binary.Binary
+			err := bin.UnmarshalText(test.Input)
+			assert.NoError(t, err)
+			assert.Equal(t, string(test.Output), string(bin))
+		})
+	}
+}

--- a/binary/binary_test.go
+++ b/binary/binary_test.go
@@ -5,6 +5,7 @@
 package binary_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ import (
 	"github.com/palantir/pkg/binary"
 )
 
-func TestBinary_MarshalText(t *testing.T) {
+func TestBinary_Marshal(t *testing.T) {
 	for _, test := range []struct {
 		Name   string
 		Input  []byte
@@ -21,18 +22,18 @@ func TestBinary_MarshalText(t *testing.T) {
 		{
 			Name:   "hello world",
 			Input:  []byte(`hello world`),
-			Output: []byte(`aGVsbG8gd29ybGQ=`),
+			Output: []byte(`"aGVsbG8gd29ybGQ="`),
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			out, err := binary.New(test.Input).MarshalText()
+			out, err := json.Marshal(binary.New(test.Input))
 			assert.NoError(t, err)
 			assert.Equal(t, string(test.Output), string(out))
 		})
 	}
 }
 
-func TestBinary_UnmarshalText(t *testing.T) {
+func TestBinary_Unmarshal(t *testing.T) {
 	for _, test := range []struct {
 		Name   string
 		Input  []byte
@@ -40,15 +41,17 @@ func TestBinary_UnmarshalText(t *testing.T) {
 	}{
 		{
 			Name:   "hello world",
-			Input:  []byte(`aGVsbG8gd29ybGQ=`),
+			Input:  []byte(`"aGVsbG8gd29ybGQ="`),
 			Output: []byte(`hello world`),
 		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			var bin binary.Binary
-			err := bin.UnmarshalText(test.Input)
+			err := json.Unmarshal(test.Input, &bin)
 			assert.NoError(t, err)
-			assert.Equal(t, string(test.Output), string(bin.Data))
+			bytes, err := bin.Bytes()
+			assert.NoError(t, err)
+			assert.Equal(t, string(test.Output), string(bytes))
 		})
 	}
 }


### PR DESCRIPTION
The conjure wire specification requires binary data to be encoded in base64 when serialized as a string. This helper type facilitates this encoding when used as a struct/map/slice member.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/137)
<!-- Reviewable:end -->
