### PR TITLE
Add boolean package

### DIFF
--- a/boolean/boolean.go
+++ b/boolean/boolean.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package boolean
+
+import (
+	"strconv"
+)
+
+// Boolean wraps a bool value and provides encoding methods allowing its use as a map key in JSON objects.
+type Boolean bool
+
+func (b Boolean) MarshalText() ([]byte, error) {
+	return []byte(strconv.FormatBool(bool(b))), nil
+}
+
+func (b *Boolean) UnmarshalText(data []byte) error {
+	rawBoolean, err := strconv.ParseBool(string(data))
+	if err != nil {
+		return err
+	}
+	*b = Boolean(rawBoolean)
+	return nil
+}

--- a/boolean/boolean_test.go
+++ b/boolean/boolean_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package boolean_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/palantir/pkg/boolean"
+)
+
+func TestBoolean(t *testing.T) {
+	for _, test := range []struct {
+		Name    string
+		mapJSON string
+		mapVal  map[boolean.Boolean]bool
+	}{
+		{
+			Name:    "basic",
+			mapJSON: `{"true":true,"false":false}`,
+			mapVal:  map[boolean.Boolean]bool{true: true, false: false},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			var decodedMap map[boolean.Boolean]bool
+			err := json.Unmarshal([]byte(test.mapJSON), &decodedMap)
+			require.NoError(t, err)
+			require.Equal(t, test.mapVal, decodedMap)
+			encodedJSON, err := json.Marshal(decodedMap)
+			require.NoError(t, err)
+			require.JSONEq(t, test.mapJSON, string(encodedJSON))
+		})
+	}
+}


### PR DESCRIPTION
Similar motivations to #137. `map[bool]bool` is not a valid target for `encoding/json`, but it is valid in conjure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/138)
<!-- Reviewable:end -->
