### PR TITLE
metrics: copy tags list before serializing

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -385,7 +385,5 @@ func toMetricTagsID(name string, tags Tags) metricTagsID {
 
 // We copy the tag slice so that subsequent in-place mutations (sorting) do not affect the input slice.
 func copyTags(tags Tags) Tags {
-	tagsCopy := make(Tags, len(tags))
-	copy(tagsCopy, tags)
-	return tagsCopy
+	return append(tags[:0:0], tags...) // https://github.com/go101/go101/wiki/How-to-efficiently-clone-a-slice%3F
 }

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -305,31 +305,31 @@ func (r *rootRegistry) Unregister(name string, tags ...Tag) {
 }
 
 func (r *rootRegistry) Counter(name string, tags ...Tag) metrics.Counter {
-	return metrics.GetOrRegisterCounter(r.registerMetric(name, tags), r.registry)
+	return metrics.GetOrRegisterCounter(r.registerMetric(name, copyTags(tags)), r.registry)
 }
 
 func (r *rootRegistry) Gauge(name string, tags ...Tag) metrics.Gauge {
-	return metrics.GetOrRegisterGauge(r.registerMetric(name, tags), r.registry)
+	return metrics.GetOrRegisterGauge(r.registerMetric(name, copyTags(tags)), r.registry)
 }
 
 func (r *rootRegistry) GaugeFloat64(name string, tags ...Tag) metrics.GaugeFloat64 {
-	return metrics.GetOrRegisterGaugeFloat64(r.registerMetric(name, tags), r.registry)
+	return metrics.GetOrRegisterGaugeFloat64(r.registerMetric(name, copyTags(tags)), r.registry)
 }
 
 func (r *rootRegistry) Meter(name string, tags ...Tag) metrics.Meter {
-	return metrics.GetOrRegisterMeter(r.registerMetric(name, tags), r.registry)
+	return metrics.GetOrRegisterMeter(r.registerMetric(name, copyTags(tags)), r.registry)
 }
 
 func (r *rootRegistry) Timer(name string, tags ...Tag) metrics.Timer {
-	return metrics.GetOrRegisterTimer(r.registerMetric(name, tags), r.registry)
+	return metrics.GetOrRegisterTimer(r.registerMetric(name, copyTags(tags)), r.registry)
 }
 
 func (r *rootRegistry) Histogram(name string, tags ...Tag) metrics.Histogram {
-	return r.HistogramWithSample(name, DefaultSample(), tags...)
+	return r.HistogramWithSample(name, DefaultSample(), copyTags(tags)...)
 }
 
 func (r *rootRegistry) HistogramWithSample(name string, sample metrics.Sample, tags ...Tag) metrics.Histogram {
-	return metrics.GetOrRegisterHistogram(r.registerMetric(name, tags), r.registry, sample)
+	return metrics.GetOrRegisterHistogram(r.registerMetric(name, copyTags(tags)), r.registry, sample)
 }
 
 func (r *rootRegistry) Registry() metrics.Registry {
@@ -381,4 +381,11 @@ func toMetricTagsID(name string, tags Tags) metricTagsID {
 		_, _ = buf.WriteString(tag.keyValue)
 	}
 	return metricTagsID(buf.Bytes())
+}
+
+// We copy the tag slice so that subsequent in-place mutations (sorting) do not affect the input slice.
+func copyTags(tags Tags) Tags {
+	tagsCopy := make(Tags, len(tags))
+	copy(tagsCopy, tags)
+	return tagsCopy
 }

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -283,7 +283,6 @@ func (r *rootRegistry) Each(f MetricVisitor) {
 			name = metricWithTags.name
 			tags = make(Tags, len(metricWithTags.tags))
 			copy(tags, metricWithTags.tags)
-			sort.Sort(tags)
 		} else {
 			// Metric was added to rcrowley registry outside of our registry.
 			// This is likely a go runtime metric (nothing else is exposed).

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -299,9 +299,7 @@ func (r *rootRegistry) Each(f MetricVisitor) {
 }
 
 func (r *rootRegistry) Unregister(name string, tags ...Tag) {
-	// We copy the tag slice so that subsequent in-place mutations (sorting) do not affect the input slice.
-	tagsCopy := append(tags[:0:0], tags...) // https://github.com/go101/go101/wiki/How-to-efficiently-clone-a-slice%3F
-	metricID := toMetricTagsID(name, tagsCopy)
+	metricID := toMetricTagsID(name, newSortedTags(tags))
 	r.registry.Unregister(string(metricID))
 }
 
@@ -342,14 +340,12 @@ func DefaultSample() metrics.Sample {
 }
 
 func (r *rootRegistry) registerMetric(name string, tags Tags) string {
-	// We copy the tag slice so that subsequent in-place mutations (sorting) do not affect the input slice.
-	tagsCopy := append(tags[:0:0], tags...) // https://github.com/go101/go101/wiki/How-to-efficiently-clone-a-slice%3F
-
-	metricID := toMetricTagsID(name, tagsCopy)
+	sortedTags := newSortedTags(tags)
+	metricID := toMetricTagsID(name, sortedTags)
 	r.idToMetricMutex.Lock()
 	r.idToMetricWithTags[metricID] = metricWithTags{
 		name: name,
-		tags: tagsCopy,
+		tags: sortedTags,
 	}
 	r.idToMetricMutex.Unlock()
 	return string(metricID)
@@ -368,10 +364,9 @@ type metricTagsID string
 
 // toMetricTagsID generates the metricTagsID identifier for the metricWithTags. A unique {metricName, set<Tag>} input will
 // generate a unique output. This implementation tries to minimize memory allocation and runtime.
+// The ID is created by adding the tags in the order they are provided (this means that, if the caller wants a specific set of tags to always
+// result in the same ID, they must sort the Tags before providing them to this function).
 func toMetricTagsID(name string, tags Tags) metricTagsID {
-	// TODO(maybe): Ensure tags is already sorted when it comes in so we can remove this.
-	sort.Sort(tags)
-
 	// calculate how large to make our byte buffer below
 	bufSize := len(name)
 	for _, t := range tags {
@@ -385,4 +380,11 @@ func toMetricTagsID(name string, tags Tags) metricTagsID {
 		_, _ = buf.WriteString(tag.keyValue)
 	}
 	return metricTagsID(buf.Bytes())
+}
+
+// newSortedTags copies the tag slice before sorting so that in-place mutation does not affect the input slice.
+func newSortedTags(tags Tags) Tags {
+	tagsCopy := append(tags[:0:0], tags...)
+	sort.Sort(tagsCopy)
+	return tagsCopy
 }

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -73,6 +73,16 @@ func TestMetricsWithTags(t *testing.T) {
 	assert.Equal(t, wantTags, gotTags)
 }
 
+func TestMetricDoesNotMutateInputTagSlice(t *testing.T) {
+	root := metrics.NewRootMetricsRegistry()
+
+	unsortedTags := metrics.Tags{metrics.MustNewTag("b", "b"), metrics.MustNewTag("a", "a")}
+
+	root.Counter("my-counter", unsortedTags...).Inc(1)
+
+	assert.Equal(t, metrics.Tags{metrics.MustNewTag("b", "b"), metrics.MustNewTag("a", "a")}, unsortedTags)
+}
+
 // Prefix should be used as provided (no case conversion/normalization), while tags should always be converted to
 // lowercase.
 func TestMetricsCasing(t *testing.T) {


### PR DESCRIPTION
Fixes a bug introduced in #130 where the `tags` slice can be mutated by `sort.Sort`, affecting caller code unexpectedly.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/143)
<!-- Reviewable:end -->
