### PR TITLE
Fix memory leak in Unregister

### DIFF
--- a/metrics/registry_internal_test.go
+++ b/metrics/registry_internal_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootRegistry_UnregisterReleasesResources(t *testing.T) {
+	// register root metrics
+	root := NewRootMetricsRegistry().(*rootRegistry)
+
+	id := toMetricTagsID("my-counter", Tags{})
+
+	// register metric
+	root.Counter("my-counter").Inc(1)
+	assert.Contains(t, root.idToMetricWithTags, id)
+
+	// unregister metric
+	root.Unregister("my-counter")
+	assert.NotContains(t, root.idToMetricWithTags, id)
+}


### PR DESCRIPTION
We were leaking memory by failing to clean up metricIds from our internal map. This adds that cleanup while preserving correctness guarantees in `Each()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/145)
<!-- Reviewable:end -->
