### PR TITLE
Metrics: creating tags with fallback value

### DIFF
--- a/metrics/tag.go
+++ b/metrics/tag.go
@@ -76,7 +76,7 @@ func MustNewTag(k, v string) Tag {
 	return t
 }
 
-// MustNewTagWithKnownKey returns the result of calling NewTag, but panics only if the key input is invalid.
+// MustNewTagWithFallbackValue returns the result of calling NewTag, but panics only if the key input is invalid.
 // If the value input is invalid, it will be replaced with the fallback value.
 func MustNewTagWithFallbackValue(k, v, fallback string) Tag {
 	tag, err := NewTag(k, v)

--- a/metrics/tag.go
+++ b/metrics/tag.go
@@ -76,6 +76,16 @@ func MustNewTag(k, v string) Tag {
 	return t
 }
 
+// MustNewTagWithKnownKey returns the result of calling NewTag, but panics only if the key input is invalid.
+// If the value input is invalid, it will be replaced with the fallback value.
+func MustNewTagWithFallbackValue(k, v, fallback string) Tag {
+	tag, err := NewTag(k, v)
+	if err != nil {
+		return MustNewTag(k, fallback)
+	}
+	return tag
+}
+
 // NewTag returns a tag that uses the provided key and value. The returned tag is normalized to conform with the DataDog
 // tag specification. The key and value must be non-empty and the key must begin with a letter. The string form of the
 // returned tag is "normalized(k):normalized(v)".

--- a/metrics/tag.go
+++ b/metrics/tag.go
@@ -76,9 +76,9 @@ func MustNewTag(k, v string) Tag {
 	return t
 }
 
-// MustNewTagWithFallbackValue returns the result of calling NewTag, but panics only if the key input is invalid.
-// If the value input is invalid, it will be replaced with the fallback value.
-func MustNewTagWithFallbackValue(k, v, fallback string) Tag {
+// NewTagWithFallbackValue returns the result of calling NewTag, and if that fails, calls MustNewTag with a fallback
+// value. Note: because MustNewTag will panic if it fails, both the key and fallback value must be known to be valid.
+func NewTagWithFallbackValue(k, v, fallback string) Tag {
 	tag, err := NewTag(k, v)
 	if err != nil {
 		return MustNewTag(k, fallback)

--- a/metrics/tag.go
+++ b/metrics/tag.go
@@ -77,7 +77,9 @@ func MustNewTag(k, v string) Tag {
 }
 
 // NewTagWithFallbackValue returns the result of calling NewTag, and if that fails, calls MustNewTag with a fallback
-// value. Note: because MustNewTag will panic if it fails, both the key and fallback value must be known to be valid.
+// value. This function is useful when the value is provided as a runtime input and the desired behavior is to fall back
+// to using a known valid value (e.g., "unknown") when the value is invalid. Note: because MustNewTag will panic if it
+// fails, both the key and fallback value must be known valid.
 func NewTagWithFallbackValue(k, v, fallback string) Tag {
 	tag, err := NewTag(k, v)
 	if err != nil {


### PR DESCRIPTION
We frequently want to create a tag with a known key, but potentially invalid value, in which case we want to fall back to a known value such as the string `unknown`. This allows us to do so without repeatedly rewriting the same fallback code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/152)
<!-- Reviewable:end -->
