### PR TITLE
Add additional option to use fewer runtime metrics

### DIFF
--- a/metrics/registry_internal_test.go
+++ b/metrics/registry_internal_test.go
@@ -5,6 +5,7 @@
 package metrics
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,4 +24,9 @@ func TestRootRegistry_UnregisterReleasesResources(t *testing.T) {
 	// unregister metric
 	root.Unregister("my-counter")
 	assert.NotContains(t, root.idToMetricWithTags, id)
+}
+
+func TestRegistry(t *testing.T) {
+	fmt.Println(len(goRuntimeLiteMetricsToExclude))
+	fmt.Println(len(goRuntimeMetricsToExclude))
 }


### PR DESCRIPTION
Not super sure how I feel about this PR at the moment, but wanted to provide some ability for users to opt-out of getting some of the runtime stats that they might not care about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/178)
<!-- Reviewable:end -->
