### PR TITLE
Change backoff semantics in case of initialBackoff

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -124,6 +124,7 @@ func WithMaxAttempts(maxAttempts int) Option {
 // WithInitialBackoff sets initial backoff.
 //
 // If initial backoff option is not used, then default value of 50 milliseconds is used.
+// If initial backoff is larger than max backoff, it takes precedence.
 func WithInitialBackoff(initialBackoff time.Duration) Option {
 	return func(o *options) {
 		o.initialBackoff = initialBackoff
@@ -180,6 +181,8 @@ func Start(ctx context.Context, opts ...Option) Retrier {
 	for _, option := range opts {
 		option(&r.options)
 	}
+	// If initial backoff is larger than max backoff, it takes precedence.
+	r.options.maxBackoff = max(r.options.maxBackoff, r.options.initialBackoff)
 	r.Reset()
 	return r
 }
@@ -247,11 +250,7 @@ func (r *retrier) Next() bool {
 func (r retrier) retryIn() time.Duration {
 	backoff := float64(r.options.initialBackoff) * math.Pow(r.options.multiplier, float64(r.currentAttempt))
 	if r.options.maxBackoff != 0 && backoff > float64(r.options.maxBackoff) {
-		if r.options.initialBackoff > r.options.maxBackoff {
-			backoff = float64(r.options.initialBackoff)
-		} else {
-			backoff = float64(r.options.maxBackoff)
-		}
+		backoff = float64(r.options.maxBackoff)
 	}
 
 	var delta = r.options.randomizationFactor * backoff
@@ -262,4 +261,11 @@ func (r retrier) retryIn() time.Duration {
 
 func (r retrier) CurrentAttempt() int {
 	return r.currentAttempt
+}
+
+func max(a, b time.Duration) time.Duration {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -247,7 +247,11 @@ func (r *retrier) Next() bool {
 func (r retrier) retryIn() time.Duration {
 	backoff := float64(r.options.initialBackoff) * math.Pow(r.options.multiplier, float64(r.currentAttempt))
 	if r.options.maxBackoff != 0 && backoff > float64(r.options.maxBackoff) {
-		backoff = float64(r.options.maxBackoff)
+		if r.options.initialBackoff > r.options.maxBackoff {
+			backoff = float64(r.options.initialBackoff)
+		} else {
+			backoff = float64(r.options.maxBackoff)
+		}
 	}
 
 	var delta = r.options.randomizationFactor * backoff

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -78,6 +78,25 @@ func TestRetrier_Next_WithMaxBackoff(t *testing.T) {
 	}
 }
 
+func TestRetrier_Next_WithInitialBackoffLargerThanMax(t *testing.T) {
+	const initialBackoff = time.Second * 5
+	const maxBackoff = time.Second * 2
+
+	options := []Option{
+		WithInitialBackoff(initialBackoff),
+		WithMaxBackoff(maxBackoff),
+		WithMultiplier(2),
+		WithMaxAttempts(11),
+		WithRandomizationFactor(0),
+	}
+
+	r := Start(context.Background(), options...).(*retrier)
+	d := r.retryIn()
+	if d != initialBackoff {
+		t.Fatalf("expected initial backoff to be used: %s vs %s", d, initialBackoff)
+	}
+}
+
 func TestRetrier_Next_WithMaxAttempts(t *testing.T) {
 	const maxAttempts = 2
 


### PR DESCRIPTION
A not uncommon pattern is to use an initial backoff that is larger than the default max backoff. For example:

```
err = retry.Do(ctx, func() error {
	// do things
}, retry.WithMaxAttempts(5), retry.WithInitialBackoff(15*time.Second), retry.WithMultiplier(1))
```

I'd expect this to retry 5 times, every 15 seconds. However, because the default backoff is 2s, we end up retrying every two seconds.

The proposed change is to use the larger of max backoff or initial backoff in situations where the current backoff is larger than the max backoff.

Explicitly setting your initial backoff larger than your max backoff is nonsensical anyways, so I haven't been able to come up with an example where this change is detrimental.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/186)
<!-- Reviewable:end -->
