### PR TITLE
stop overriding max backoff when none is set

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -115,6 +115,8 @@ type Option func(r *options)
 // Max attempts of 0 indicates no limit.
 //
 // If max attempts option is not used, then default value of 0 is used.
+// If initial backoff is larger than max backoff and the max backoff is nonzero, the initial backoff will be
+// used as the max.
 func WithMaxAttempts(maxAttempts int) Option {
 	return func(o *options) {
 		o.maxAttempts = maxAttempts
@@ -124,7 +126,8 @@ func WithMaxAttempts(maxAttempts int) Option {
 // WithInitialBackoff sets initial backoff.
 //
 // If initial backoff option is not used, then default value of 50 milliseconds is used.
-// If initial backoff is larger than max backoff, it takes precedence.
+// If initial backoff is larger than max backoff and the max backoff is nonzero, the initial backoff will be
+// used as the max.
 func WithInitialBackoff(initialBackoff time.Duration) Option {
 	return func(o *options) {
 		o.initialBackoff = initialBackoff
@@ -182,7 +185,7 @@ func Start(ctx context.Context, opts ...Option) Retrier {
 		option(&r.options)
 	}
 	if r.options.maxBackoff != 0 {
-		// If initial backoff is larger than max backoff, it takes precedence.
+		// If initial backoff is larger than max backoff and the max backoff is set, initial takes precedence.
 		r.options.maxBackoff = max(r.options.maxBackoff, r.options.initialBackoff)
 	}
 	r.Reset()

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -181,8 +181,10 @@ func Start(ctx context.Context, opts ...Option) Retrier {
 	for _, option := range opts {
 		option(&r.options)
 	}
-	// If initial backoff is larger than max backoff, it takes precedence.
-	r.options.maxBackoff = max(r.options.maxBackoff, r.options.initialBackoff)
+	if r.options.maxBackoff != 0 {
+		// If initial backoff is larger than max backoff, it takes precedence.
+		r.options.maxBackoff = max(r.options.maxBackoff, r.options.initialBackoff)
+	}
 	r.Reset()
 	return r
 }

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -184,8 +184,8 @@ func Start(ctx context.Context, opts ...Option) Retrier {
 	for _, option := range opts {
 		option(&r.options)
 	}
+	// If initial backoff is larger than max backoff and the max backoff is set, initial takes precedence.
 	if r.options.maxBackoff != 0 {
-		// If initial backoff is larger than max backoff and the max backoff is set, initial takes precedence.
 		r.options.maxBackoff = max(r.options.maxBackoff, r.options.initialBackoff)
 	}
 	r.Reset()

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -115,8 +115,6 @@ type Option func(r *options)
 // Max attempts of 0 indicates no limit.
 //
 // If max attempts option is not used, then default value of 0 is used.
-// If initial backoff is larger than max backoff and the max backoff is nonzero, the initial backoff will be
-// used as the max.
 func WithMaxAttempts(maxAttempts int) Option {
 	return func(o *options) {
 		o.maxAttempts = maxAttempts

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -97,6 +97,27 @@ func TestRetrier_Next_WithInitialBackoffLargerThanMax(t *testing.T) {
 	}
 }
 
+func TestRetrier_Next_WithInitialBackoffLargerThanMaxAndMaxNotSet(t *testing.T) {
+	const initialBackoff = time.Second * 5
+	const maxBackoff = 0
+	const multiplier = 2
+
+	options := []Option{
+		WithInitialBackoff(initialBackoff),
+		WithMaxBackoff(maxBackoff),
+		WithMultiplier(multiplier),
+		WithMaxAttempts(11),
+		WithRandomizationFactor(0),
+	}
+
+	r := Start(context.Background(), options...).(*retrier)
+	r.currentAttempt = 1
+	d := r.retryIn()
+	if d != initialBackoff * multiplier {
+		t.Fatalf("expected second attempt to increase backoff: %s vs %s", d, initialBackoff * multiplier)
+	}
+}
+
 func TestRetrier_Next_WithMaxAttempts(t *testing.T) {
 	const maxAttempts = 2
 

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -113,8 +113,8 @@ func TestRetrier_Next_WithInitialBackoffLargerThanMaxAndMaxNotSet(t *testing.T) 
 	r := Start(context.Background(), options...).(*retrier)
 	r.currentAttempt = 1
 	d := r.retryIn()
-	if d != initialBackoff * multiplier {
-		t.Fatalf("expected second attempt to increase backoff: %s vs %s", d, initialBackoff * multiplier)
+	if d != initialBackoff*multiplier {
+		t.Fatalf("expected second attempt to increase backoff: %s vs %s", d, initialBackoff*multiplier)
 	}
 }
 


### PR DESCRIPTION
When adding functionality to override the max backoff, we need to special case when no backoff is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/189)
<!-- Reviewable:end -->
