### PR TITLE
AllowRoot setting to control if a cli is allowed to run as root

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -25,6 +25,7 @@ type App struct {
 	OnExit         OnExit
 	ContextConfig  func(Context, context.Context) context.Context
 	ContextOptions []ContextOption
+	AllowRoot      bool
 }
 
 type Option func(*App)
@@ -33,9 +34,10 @@ type ContextOption func(*Context)
 
 func NewApp(opts ...Option) *App {
 	app := &App{
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-		OnExit: newOnExit(),
+		Stdout:    os.Stdout,
+		Stderr:    os.Stderr,
+		OnExit:    newOnExit(),
+		AllowRoot: false,
 	}
 	for _, opt := range opts {
 		opt(app)

--- a/cli/run.go
+++ b/cli/run.go
@@ -37,6 +37,13 @@ func (app *App) Run(args []string) (exitStatus int) {
 		return 0
 	}
 
+	if !app.AllowRoot {
+		if syscall.Getuid() == 0 {
+			ctx.Errorf("%v\n", "Root is not allowed to run this program.")
+			return 1
+		}
+	}
+
 	baseContext := context.Background()
 	if app.ContextConfig != nil {
 		baseContext = app.ContextConfig(ctx, baseContext)


### PR DESCRIPTION
Adds new `AllowRoot` boolean setting to control if an implementation of cli App is allowed to run as UID 0 (root).
Defaults to `false`.