### PR TITLE
Upgrade go versions to 1.14/1.15 and godel to 2.26.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,25 +4,34 @@ checkout-path: &checkout-path
 version: 2.1
 
 orbs:
-  go: palantir/go@0.0.14
-  godel: palantir/godel@0.0.14
+  go: palantir/go@0.0.18
+  godel: palantir/godel@0.0.18
 
 jobs:
   verify-circleci:
     working_directory: /go/src/github.com/palantir/pkg
     docker:
-      - image: "golang:1.13.4"
+      - image: "golang:1.15.6"
+    resource_class: small
     steps:
       - checkout
       - run: go version
       - run: go run .circleci/generate.go .
       - run: diff  <(cat .circleci/config.yml) <(go run .circleci/generate.go .)
+  circle-all:
+    docker:
+      - image: "golang:1.15.6"
+    resource_class: small
+    steps:
+      - run: echo "All required jobs run successfully"
 
 workflows:
   version: 2
   verify-test:
     jobs:
       - verify-circleci
+      - circle-all:
+          requires: [ verify-circleci, bearertoken-verify, bearertoken-test-go-1.14, binary-verify, binary-test-go-1.14, boolean-verify, boolean-test-go-1.14, bytesbuffers-verify, bytesbuffers-test-go-1.14, cli-verify, cli-test-go-1.14, cobracli-verify, cobracli-test-go-1.14, datetime-verify, datetime-test-go-1.14, gittest-verify, gittest-test-go-1.14, httpclient-verify, httpclient-test-go-1.14, httpserver-verify, httpserver-test-go-1.14, matcher-verify, matcher-test-go-1.14, merge-verify, merge-test-go-1.14, metrics-verify, metrics-test-go-1.14, objmatcher-verify, objmatcher-test-go-1.14, pkgpath-verify, pkgpath-test-go-1.14, retry-verify, retry-test-go-1.14, rid-verify, rid-test-go-1.14, safehttp-verify, safehttp-test-go-1.14, safejson-verify, safejson-test-go-1.14, safelong-verify, safelong-test-go-1.14, safeyaml-verify, safeyaml-test-go-1.14, signals-verify, signals-test-go-1.14, specdir-verify, specdir-test-go-1.14, tableprinter-verify, tableprinter-test-go-1.14, tlsconfig-verify, tlsconfig-test-go-1.14, transform-verify, transform-test-go-1.14, typenames-verify, typenames-test-go-1.14, uuid-verify, uuid-test-go-1.14 ]
 
       # bearertoken
       - godel/verify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,14 +31,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/bearertoken
       - godel/test:
-          name: bearertoken-test-go-1.12
+          name: bearertoken-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/bearertoken
           requires:
             - bearertoken-verify
@@ -50,14 +50,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/binary
       - godel/test:
-          name: binary-test-go-1.12
+          name: binary-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/binary
           requires:
             - binary-verify
@@ -69,14 +69,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/boolean
       - godel/test:
-          name: boolean-test-go-1.12
+          name: boolean-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/boolean
           requires:
             - boolean-verify
@@ -88,14 +88,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/bytesbuffers
       - godel/test:
-          name: bytesbuffers-test-go-1.12
+          name: bytesbuffers-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/bytesbuffers
           requires:
             - bytesbuffers-verify
@@ -107,14 +107,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/cli
       - godel/test:
-          name: cli-test-go-1.12
+          name: cli-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/cli
           requires:
             - cli-verify
@@ -126,14 +126,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/cobracli
       - godel/test:
-          name: cobracli-test-go-1.12
+          name: cobracli-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/cobracli
           requires:
             - cobracli-verify
@@ -145,14 +145,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/datetime
       - godel/test:
-          name: datetime-test-go-1.12
+          name: datetime-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/datetime
           requires:
             - datetime-verify
@@ -164,14 +164,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/gittest
       - godel/test:
-          name: gittest-test-go-1.12
+          name: gittest-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/gittest
           requires:
             - gittest-verify
@@ -183,14 +183,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/httpclient
       - godel/test:
-          name: httpclient-test-go-1.12
+          name: httpclient-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/httpclient
           requires:
             - httpclient-verify
@@ -202,14 +202,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/httpserver
       - godel/test:
-          name: httpserver-test-go-1.12
+          name: httpserver-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/httpserver
           requires:
             - httpserver-verify
@@ -221,14 +221,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/matcher
       - godel/test:
-          name: matcher-test-go-1.12
+          name: matcher-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/matcher
           requires:
             - matcher-verify
@@ -240,14 +240,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/merge
       - godel/test:
-          name: merge-test-go-1.12
+          name: merge-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/merge
           requires:
             - merge-verify
@@ -259,14 +259,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/metrics
       - godel/test:
-          name: metrics-test-go-1.12
+          name: metrics-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/metrics
           requires:
             - metrics-verify
@@ -278,14 +278,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/objmatcher
       - godel/test:
-          name: objmatcher-test-go-1.12
+          name: objmatcher-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/objmatcher
           requires:
             - objmatcher-verify
@@ -297,14 +297,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/pkgpath
       - godel/test:
-          name: pkgpath-test-go-1.12
+          name: pkgpath-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/pkgpath
           requires:
             - pkgpath-verify
@@ -316,14 +316,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/retry
       - godel/test:
-          name: retry-test-go-1.12
+          name: retry-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/retry
           requires:
             - retry-verify
@@ -335,14 +335,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/rid
       - godel/test:
-          name: rid-test-go-1.12
+          name: rid-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/rid
           requires:
             - rid-verify
@@ -354,14 +354,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/safehttp
       - godel/test:
-          name: safehttp-test-go-1.12
+          name: safehttp-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/safehttp
           requires:
             - safehttp-verify
@@ -373,14 +373,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/safejson
       - godel/test:
-          name: safejson-test-go-1.12
+          name: safejson-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/safejson
           requires:
             - safejson-verify
@@ -392,14 +392,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/safelong
       - godel/test:
-          name: safelong-test-go-1.12
+          name: safelong-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/safelong
           requires:
             - safelong-verify
@@ -411,14 +411,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/safeyaml
       - godel/test:
-          name: safeyaml-test-go-1.12
+          name: safeyaml-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/safeyaml
           requires:
             - safeyaml-verify
@@ -430,14 +430,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/signals
       - godel/test:
-          name: signals-test-go-1.12
+          name: signals-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/signals
           requires:
             - signals-verify
@@ -449,14 +449,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/specdir
       - godel/test:
-          name: specdir-test-go-1.12
+          name: specdir-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/specdir
           requires:
             - specdir-verify
@@ -468,14 +468,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/tableprinter
       - godel/test:
-          name: tableprinter-test-go-1.12
+          name: tableprinter-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/tableprinter
           requires:
             - tableprinter-verify
@@ -487,14 +487,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/tlsconfig
       - godel/test:
-          name: tlsconfig-test-go-1.12
+          name: tlsconfig-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/tlsconfig
           requires:
             - tlsconfig-verify
@@ -506,14 +506,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/transform
       - godel/test:
-          name: transform-test-go-1.12
+          name: transform-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/transform
           requires:
             - transform-verify
@@ -525,14 +525,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/typenames
       - godel/test:
-          name: typenames-test-go-1.12
+          name: typenames-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/typenames
           requires:
             - typenames-verify
@@ -544,14 +544,14 @@ workflows:
           include-tests: true
           executor:
             name: go/golang
-            version: 1.13.4
+            version: 1.15.6
             owner-repo: palantir/pkg/uuid
       - godel/test:
-          name: uuid-test-go-1.12
+          name: uuid-test-go-1.14
           <<: *checkout-path
           executor:
             name: go/golang
-            version: 1.12.13
+            version: 1.14.13
             owner-repo: palantir/pkg/uuid
           requires:
             - uuid-verify

--- a/.circleci/generate.go
+++ b/.circleci/generate.go
@@ -79,7 +79,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	configYML, err := createConfigYML(mods, "1.13.4", "1.12.13")
+	configYML, err := createConfigYML(mods, "1.15.6", "1.14.13")
 	if err != nil {
 		panic(err)
 	}

--- a/bearertoken/go.mod
+++ b/bearertoken/go.mod
@@ -2,4 +2,4 @@ module github.com/palantir/pkg/bearertoken
 
 require github.com/palantir/pkg v1.0.1
 
-go 1.13
+go 1.14

--- a/bearertoken/godel/config/godel.properties
+++ b/bearertoken/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/bearertoken/godelw
+++ b/bearertoken/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/bearertoken/vendor/modules.txt
+++ b/bearertoken/vendor/modules.txt
@@ -1,2 +1,3 @@
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg

--- a/binary/go.mod
+++ b/binary/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/binary
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/binary/godel/config/godel.properties
+++ b/binary/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/binary/godelw
+++ b/binary/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/binary/vendor/modules.txt
+++ b/binary/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2

--- a/boolean/go.mod
+++ b/boolean/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/boolean
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/boolean/godel/config/godel.properties
+++ b/boolean/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.25.0/godel-2.25.0.tgz
-distributionSHA256=f9a58181cfc1c709e9ac4a763bce386fb4e0c5ad24a635120b7d592c60e10206
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/boolean/godelw
+++ b/boolean/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.25.0
-DARWIN_CHECKSUM=06c92c3b973198c0c4a57c09d853c6f2235d02d4c2098d6303211d31a9c27e5d
-LINUX_CHECKSUM=731d00d75c2607258326f5cbbe3c0b4cdc3e1526c55b3539246094ca2f1a22fc
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/boolean/vendor/modules.txt
+++ b/boolean/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/bytesbuffers/go.mod
+++ b/bytesbuffers/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/bytesbuffers
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/bytesbuffers/godel/config/godel.properties
+++ b/bytesbuffers/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/bytesbuffers/godelw
+++ b/bytesbuffers/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/bytesbuffers/vendor/modules.txt
+++ b/bytesbuffers/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/cli
 
-go 1.13
+go 1.14
 
 require (
 	github.com/mitchellh/go-wordwrap v1.0.0

--- a/cli/godel/config/godel.properties
+++ b/cli/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/cli/godelw
+++ b/cli/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/cli/on_exit.go
+++ b/cli/on_exit.go
@@ -44,9 +44,11 @@ type registration struct {
 
 type byPriorityLIFO []registration
 
-func (a byPriorityLIFO) Len() int           { return len(a) }
-func (a byPriorityLIFO) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a byPriorityLIFO) Less(i, j int) bool { return a[i].priority > a[j].priority || a[i].id > a[j].id }
+func (a byPriorityLIFO) Len() int      { return len(a) }
+func (a byPriorityLIFO) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a byPriorityLIFO) Less(i, j int) bool {
+	return a[i].priority > a[j].priority || a[i].id > a[j].id
+}
 
 type onExit struct {
 	counter       OnExitID

--- a/cli/vendor/modules.txt
+++ b/cli/vendor/modules.txt
@@ -16,10 +16,12 @@ github.com/hashicorp/hcl/json/token
 # github.com/magiconair/properties v1.8.1
 github.com/magiconair/properties
 # github.com/mitchellh/go-wordwrap v1.0.0
+## explicit
 github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pelletier/go-toml v1.2.0
 github.com/pelletier/go-toml
@@ -35,13 +37,16 @@ github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.3
 github.com/spf13/pflag
 # github.com/spf13/viper v1.5.0
+## explicit
 github.com/spf13/viper
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
 # golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f
+## explicit
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/sys v0.0.0-20190412213103-97732733099d
 golang.org/x/sys/unix

--- a/cobracli/go.mod
+++ b/cobracli/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/cobracli
 
-go 1.13
+go 1.14
 
 require (
 	github.com/nmiyake/pkg/errorstringer v1.0.0

--- a/cobracli/godel/config/godel.properties
+++ b/cobracli/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/cobracli/godelw
+++ b/cobracli/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/cobracli/vendor/modules.txt
+++ b/cobracli/vendor/modules.txt
@@ -3,18 +3,23 @@ github.com/davecgh/go-spew/spew
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/nmiyake/pkg/errorstringer v1.0.0
+## explicit
 github.com/nmiyake/pkg/errorstringer
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pkg/errors v0.8.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/spf13/cobra v0.0.5
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.3
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/datetime/datetime_go114_test.go
+++ b/datetime/datetime_go114_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// In go 1.15 the extra text values got quoted.
+// Maintain a test for old go until we no longer support 1.14.
+// +build !go1.15
+
+package datetime_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/palantir/pkg/datetime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateTimeUnmarshalInvalid(t *testing.T) {
+	for i, currCase := range []struct {
+		input   string
+		wantErr string
+	}{
+		{
+			input:   `"foo"`,
+			wantErr: "parsing time \"foo\" as \"2006-01-02T15:04:05.999999999Z07:00\": cannot parse \"foo\" as \"2006\"",
+		},
+		{
+			input:   `"2017-01-02T04:04:05.000000000+01:00[Europe/Berlin"`,
+			wantErr: "parsing time \"2017-01-02T04:04:05.000000000+01:00[Europe/Berlin\": extra text: [Europe/Berlin",
+		},
+		{
+			input:   `"2017-01-02T04:04:05.000000000+01:00[[Europe/Berlin]]"`,
+			wantErr: "parsing time \"2017-01-02T04:04:05.000000000+01:00[\": extra text: [",
+		},
+	} {
+		var gotDateTime *datetime.DateTime
+		err := json.Unmarshal([]byte(currCase.input), &gotDateTime)
+		assert.EqualError(t, err, currCase.wantErr, "Case %d", i)
+	}
+}

--- a/datetime/datetime_go115_test.go
+++ b/datetime/datetime_go115_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.15
+
+package datetime_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/palantir/pkg/datetime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateTimeUnmarshalInvalid(t *testing.T) {
+	for i, currCase := range []struct {
+		input   string
+		wantErr string
+	}{
+		{
+			input:   `"foo"`,
+			wantErr: "parsing time \"foo\" as \"2006-01-02T15:04:05.999999999Z07:00\": cannot parse \"foo\" as \"2006\"",
+		},
+		{
+			input:   `"2017-01-02T04:04:05.000000000+01:00[Europe/Berlin"`,
+			wantErr: "parsing time \"2017-01-02T04:04:05.000000000+01:00[Europe/Berlin\": extra text: \"[Europe/Berlin\"",
+		},
+		{
+			input:   `"2017-01-02T04:04:05.000000000+01:00[[Europe/Berlin]]"`,
+			wantErr: "parsing time \"2017-01-02T04:04:05.000000000+01:00[\": extra text: \"[\"",
+		},
+	} {
+		var gotDateTime *datetime.DateTime
+		err := json.Unmarshal([]byte(currCase.input), &gotDateTime)
+		assert.EqualError(t, err, currCase.wantErr, "Case %d", i)
+	}
+}

--- a/datetime/datetime_test.go
+++ b/datetime/datetime_test.go
@@ -94,27 +94,3 @@ func TestDateTimeUnmarshal(t *testing.T) {
 		assert.Equal(t, wantDateTime, time.Time(gotDateTime), "Case %d", i)
 	}
 }
-
-func TestDateTimeUnmarshalInvalid(t *testing.T) {
-	for i, currCase := range []struct {
-		input   string
-		wantErr string
-	}{
-		{
-			input:   `"foo"`,
-			wantErr: "parsing time \"foo\" as \"2006-01-02T15:04:05.999999999Z07:00\": cannot parse \"foo\" as \"2006\"",
-		},
-		{
-			input:   `"2017-01-02T04:04:05.000000000+01:00[Europe/Berlin"`,
-			wantErr: "parsing time \"2017-01-02T04:04:05.000000000+01:00[Europe/Berlin\": extra text: [Europe/Berlin",
-		},
-		{
-			input:   `"2017-01-02T04:04:05.000000000+01:00[[Europe/Berlin]]"`,
-			wantErr: "parsing time \"2017-01-02T04:04:05.000000000+01:00[\": extra text: [",
-		},
-	} {
-		var gotDateTime *datetime.DateTime
-		err := json.Unmarshal([]byte(currCase.input), &gotDateTime)
-		assert.EqualError(t, err, currCase.wantErr, "Case %d", i)
-	}
-}

--- a/datetime/go.mod
+++ b/datetime/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/datetime
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/datetime/godel/config/godel.properties
+++ b/datetime/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/datetime/godelw
+++ b/datetime/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/datetime/vendor/modules.txt
+++ b/datetime/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/gittest/go.mod
+++ b/gittest/go.mod
@@ -1,5 +1,5 @@
 module github.com/palantir/pkg/gittest
 
-go 1.13
+go 1.14
 
 require github.com/palantir/pkg v1.0.1

--- a/gittest/godel/config/godel.properties
+++ b/gittest/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/gittest/godelw
+++ b/gittest/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/gittest/vendor/modules.txt
+++ b/gittest/vendor/modules.txt
@@ -1,2 +1,3 @@
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/palantir/pkg
 
-go 1.13
+go 1.14

--- a/godelw
+++ b/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.17.0
-DARWIN_CHECKSUM=d6294049b7edc3795d1d5517583f20c087422a8b8b52e8cbcc39ce2b575427ff
-LINUX_CHECKSUM=23bca1ce55bd321686e06e0b6959ad8160ef1dfa9fe0a68a515e65d19401094d
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/httpclient/go.mod
+++ b/httpclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/httpclient
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/httpclient/godel/config/godel.properties
+++ b/httpclient/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/httpclient/godelw
+++ b/httpclient/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/httpclient/vendor/modules.txt
+++ b/httpclient/vendor/modules.txt
@@ -1,6 +1,8 @@
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # golang.org/x/net v0.0.0-20191116160921-f9c825593386
+## explicit
 golang.org/x/net/http/httpguts
 golang.org/x/net/http2
 golang.org/x/net/http2/hpack

--- a/httpserver/go.mod
+++ b/httpserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/httpserver
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/httpserver/godel/config/godel.properties
+++ b/httpserver/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/httpserver/godelw
+++ b/httpserver/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/httpserver/vendor/modules.txt
+++ b/httpserver/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2

--- a/matcher/go.mod
+++ b/matcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/matcher
 
-go 1.13
+go 1.14
 
 require (
 	github.com/nmiyake/pkg/dirs v1.0.0

--- a/matcher/godel/config/godel.properties
+++ b/matcher/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/matcher/godelw
+++ b/matcher/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/matcher/vendor/modules.txt
+++ b/matcher/vendor/modules.txt
@@ -1,13 +1,17 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/nmiyake/pkg/dirs v1.0.0
+## explicit
 github.com/nmiyake/pkg/dirs
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.5
+## explicit
 gopkg.in/yaml.v2

--- a/merge/go.mod
+++ b/merge/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/merge
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/merge/godel/config/godel.properties
+++ b/merge/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/merge/godelw
+++ b/merge/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/merge/vendor/modules.txt
+++ b/merge/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/metrics
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/go-metrics v1.1.1

--- a/metrics/godel/config/godel.properties
+++ b/metrics/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/metrics/godelw
+++ b/metrics/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/metrics/vendor/modules.txt
+++ b/metrics/vendor/modules.txt
@@ -1,16 +1,21 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/go-metrics v1.1.1
+## explicit
 github.com/palantir/go-metrics
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/palantir/pkg/objmatcher v1.0.0
+## explicit
 github.com/palantir/pkg/objmatcher
 # github.com/pkg/errors v0.8.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/objmatcher/go.mod
+++ b/objmatcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/objmatcher
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/objmatcher/godel/config/godel.properties
+++ b/objmatcher/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/objmatcher/godelw
+++ b/objmatcher/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/objmatcher/vendor/modules.txt
+++ b/objmatcher/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2

--- a/pkgpath/go.mod
+++ b/pkgpath/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/pkgpath
 
-go 1.13
+go 1.14
 
 require (
 	github.com/nmiyake/pkg/dirs v1.0.0

--- a/pkgpath/godel/config/godel.properties
+++ b/pkgpath/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/pkgpath/godelw
+++ b/pkgpath/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/pkgpath/vendor/modules.txt
+++ b/pkgpath/vendor/modules.txt
@@ -1,16 +1,21 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/nmiyake/pkg/dirs v1.0.0
+## explicit
 github.com/nmiyake/pkg/dirs
 # github.com/nmiyake/pkg/gofiles v1.0.0
+## explicit
 github.com/nmiyake/pkg/gofiles
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/palantir/pkg/matcher v1.0.0
+## explicit
 github.com/palantir/pkg/matcher
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.5

--- a/retry/go.mod
+++ b/retry/go.mod
@@ -1,5 +1,5 @@
 module github.com/palantir/pkg/retry
 
-go 1.13
+go 1.14
 
 require github.com/palantir/pkg v1.0.1

--- a/retry/godel/config/godel.properties
+++ b/retry/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/retry/godelw
+++ b/retry/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/retry/vendor/modules.txt
+++ b/retry/vendor/modules.txt
@@ -1,2 +1,3 @@
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg

--- a/rid/go.mod
+++ b/rid/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/rid
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/rid/godel/config/godel.properties
+++ b/rid/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/rid/godelw
+++ b/rid/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/rid/vendor/modules.txt
+++ b/rid/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/safehttp/go.mod
+++ b/safehttp/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/safehttp
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/safehttp/godel/config/godel.properties
+++ b/safehttp/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/safehttp/godelw
+++ b/safehttp/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/safehttp/vendor/modules.txt
+++ b/safehttp/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/safejson/go.mod
+++ b/safejson/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/safejson
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/safejson/godel/config/godel.properties
+++ b/safejson/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/safejson/godelw
+++ b/safejson/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/safejson/vendor/modules.txt
+++ b/safejson/vendor/modules.txt
@@ -1,11 +1,14 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.5
+## explicit
 gopkg.in/yaml.v2

--- a/safelong/go.mod
+++ b/safelong/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/safelong
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/safelong/godel/config/godel.properties
+++ b/safelong/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/safelong/godelw
+++ b/safelong/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/safelong/vendor/modules.txt
+++ b/safelong/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/safeyaml/go.mod
+++ b/safeyaml/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/safeyaml
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/safeyaml/godel/config/godel.properties
+++ b/safeyaml/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/safeyaml/godelw
+++ b/safeyaml/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/safeyaml/vendor/modules.txt
+++ b/safeyaml/vendor/modules.txt
@@ -1,13 +1,18 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/palantir/pkg/transform v1.0.0
+## explicit
 github.com/palantir/pkg/transform
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2 => gopkg.in/yaml.v2 v2.2.1
+## explicit
 gopkg.in/yaml.v2
+# gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.1

--- a/signals/go.mod
+++ b/signals/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/signals
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/signals/godel/config/godel.properties
+++ b/signals/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/signals/godelw
+++ b/signals/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/signals/vendor/modules.txt
+++ b/signals/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/specdir/go.mod
+++ b/specdir/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/specdir
 
-go 1.13
+go 1.14
 
 require (
 	github.com/nmiyake/pkg/dirs v1.0.0

--- a/specdir/godel/config/godel.properties
+++ b/specdir/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/specdir/godelw
+++ b/specdir/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/specdir/vendor/modules.txt
+++ b/specdir/vendor/modules.txt
@@ -1,12 +1,15 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/nmiyake/pkg/dirs v1.0.0
+## explicit
 github.com/nmiyake/pkg/dirs
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/tableprinter/go.mod
+++ b/tableprinter/go.mod
@@ -1,5 +1,5 @@
 module github.com/palantir/pkg/tableprinter
 
-go 1.13
+go 1.14
 
 require github.com/palantir/pkg v1.0.1

--- a/tableprinter/godel/config/godel.properties
+++ b/tableprinter/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/tableprinter/godelw
+++ b/tableprinter/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/tableprinter/vendor/modules.txt
+++ b/tableprinter/vendor/modules.txt
@@ -1,2 +1,3 @@
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg

--- a/tlsconfig/go.mod
+++ b/tlsconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/tlsconfig
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/tlsconfig/godel/config/godel.properties
+++ b/tlsconfig/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/tlsconfig/godelw
+++ b/tlsconfig/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/tlsconfig/vendor/modules.txt
+++ b/tlsconfig/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2

--- a/transform/go.mod
+++ b/transform/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/transform
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/transform/godel/config/godel.properties
+++ b/transform/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/transform/godelw
+++ b/transform/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/transform/vendor/modules.txt
+++ b/transform/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2

--- a/typenames/go.mod
+++ b/typenames/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/typenames
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/typenames/godel/config/godel.properties
+++ b/typenames/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/typenames/godelw
+++ b/typenames/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/typenames/vendor/modules.txt
+++ b/typenames/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2

--- a/uuid/go.mod
+++ b/uuid/go.mod
@@ -1,6 +1,6 @@
 module github.com/palantir/pkg/uuid
 
-go 1.13
+go 1.14
 
 require (
 	github.com/palantir/pkg v1.0.1

--- a/uuid/godel/config/godel.properties
+++ b/uuid/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.22.0/godel-2.22.0.tgz
-distributionSHA256=c024a4dbe659adaf151cb2805646f15607f53154448b8efcd5c0964f042ac4a2
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.26.0/godel-2.26.0.tgz
+distributionSHA256=03ae0b15f6c7d04c9250bde58a60f0404f9c4410fb7171f0ee326c658d03f6c7

--- a/uuid/godelw
+++ b/uuid/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.22.0
-DARWIN_CHECKSUM=b2bedf340419d79187643bf9a9dbdd0c4c46bccdcb597717b71dd165ac7129a7
-LINUX_CHECKSUM=25d36a20d33cba39d05f8a3c2c3768b3a02a3297f129308f3e2bc8c0951ba388
+VERSION=2.26.0
+DARWIN_CHECKSUM=195d6a32f0fb357d131d444c78b3f49f7ecef2cdfdf00ee707427c76970c45ef
+LINUX_CHECKSUM=2ff4039d95fcb85891d8d9affa0294bcba40ba3b31d7fee34ca31f6f81db9c44
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {

--- a/uuid/vendor/modules.txt
+++ b/uuid/vendor/modules.txt
@@ -1,10 +1,12 @@
 # github.com/davecgh/go-spew v1.1.0
 github.com/davecgh/go-spew/spew
 # github.com/palantir/pkg v1.0.1
+## explicit
 github.com/palantir/pkg
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.4.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # gopkg.in/yaml.v2 v2.2.2


### PR DESCRIPTION
Also updates circle config to finish with a single `circle-all` task so we can have one required job instead of having to keep the list updated when changing versions or adding a new module.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/193)
<!-- Reviewable:end -->
