### PR TITLE
Fix ClientKeyPair param in tlsconfig so clients refresh by default

### DIFF
--- a/tlsconfig/common.go
+++ b/tlsconfig/common.go
@@ -79,6 +79,17 @@ func getCertificateParam(provider TLSCertProvider) configurer {
 	}
 }
 
+func certificatesParam(provider TLSCertProvider) configurer {
+	return func(cfg *tls.Config) error {
+		cert, err := provider()
+		if err != nil {
+			return fmt.Errorf("failed to load TLS certificate: %v", err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+		return nil
+	}
+}
+
 func cipherSuitesParam(cipherSuites ...uint16) configurer {
 	return func(cfg *tls.Config) error {
 		cfg.CipherSuites = cipherSuites

--- a/tlsconfig/common.go
+++ b/tlsconfig/common.go
@@ -59,20 +59,19 @@ func CertPoolFromCerts(certs ...*x509.Certificate) CertPoolProvider {
 
 type configurer func(*tls.Config) error
 
-func certificatesParam(provider TLSCertProvider) configurer {
+func getClientCertificateParam(provider TLSCertProvider) configurer {
 	return func(cfg *tls.Config) error {
-		cert, err := provider()
-		if err != nil {
-			return fmt.Errorf("failed to load TLS certificate: %v", err)
+		cfg.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := provider()
+			return &cert, err
 		}
-		cfg.Certificates = []tls.Certificate{cert}
 		return nil
 	}
 }
 
-func getClientCertificateParam(provider TLSCertProvider) configurer {
+func getCertificateParam(provider TLSCertProvider) configurer {
 	return func(cfg *tls.Config) error {
-		cfg.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		cfg.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			cert, err := provider()
 			return &cert, err
 		}

--- a/tlsconfig/common.go
+++ b/tlsconfig/common.go
@@ -59,13 +59,34 @@ func CertPoolFromCerts(certs ...*x509.Certificate) CertPoolProvider {
 
 type configurer func(*tls.Config) error
 
-func authKeyPairParam(provider TLSCertProvider) configurer {
+func certificatesParam(provider TLSCertProvider) configurer {
 	return func(cfg *tls.Config) error {
 		cert, err := provider()
 		if err != nil {
 			return fmt.Errorf("failed to load TLS certificate: %v", err)
 		}
 		cfg.Certificates = []tls.Certificate{cert}
+		return nil
+	}
+}
+
+func getCertificateParam(provider TLSCertProvider) configurer {
+	return func(cfg *tls.Config) error {
+		cfg.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := provider()
+			return &cert, err
+		}
+
+		return nil
+	}
+}
+
+func getClientCertificateParam(provider TLSCertProvider) configurer {
+	return func(cfg *tls.Config) error {
+		cfg.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := provider()
+			return &cert, err
+		}
 		return nil
 	}
 }

--- a/tlsconfig/common.go
+++ b/tlsconfig/common.go
@@ -69,16 +69,6 @@ func getClientCertificateParam(provider TLSCertProvider) configurer {
 	}
 }
 
-func getCertificateParam(provider TLSCertProvider) configurer {
-	return func(cfg *tls.Config) error {
-		cfg.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			cert, err := provider()
-			return &cert, err
-		}
-		return nil
-	}
-}
-
 func certificatesParam(provider TLSCertProvider) configurer {
 	return func(cfg *tls.Config) error {
 		cert, err := provider()

--- a/tlsconfig/common.go
+++ b/tlsconfig/common.go
@@ -70,17 +70,6 @@ func certificatesParam(provider TLSCertProvider) configurer {
 	}
 }
 
-func getCertificateParam(provider TLSCertProvider) configurer {
-	return func(cfg *tls.Config) error {
-		cfg.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-			cert, err := provider()
-			return &cert, err
-		}
-
-		return nil
-	}
-}
-
 func getClientCertificateParam(provider TLSCertProvider) configurer {
 	return func(cfg *tls.Config) error {
 		cfg.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {

--- a/tlsconfig/tlsconfig_client.go
+++ b/tlsconfig/tlsconfig_client.go
@@ -32,11 +32,11 @@ func (p clientParam) configureClient(cfg *tls.Config) error {
 	return p(cfg)
 }
 
-// ClientKeyPairFiles configures the client with the key pair that it should present to servers when communicating using
+// ClientKeyPairFiles configures the client with a static key pair for it to present to servers when communicating using
 // TLS with client authentication (2-way SSL). If neither ClientKeyPairFiles nor ClientKeyPair are provided, the client
 // will not present a certificate.
 func ClientKeyPairFiles(certFile, keyFile string) ClientParam {
-	return ClientKeyPair(TLSCertFromFiles(certFile, keyFile))
+	return clientParam(certificatesParam(TLSCertFromFiles(certFile, keyFile)))
 }
 
 // ClientKeyPair configures the client to call the provided TLSCertProvider whenever a key pair is requested when

--- a/tlsconfig/tlsconfig_client.go
+++ b/tlsconfig/tlsconfig_client.go
@@ -39,9 +39,9 @@ func ClientKeyPairFiles(certFile, keyFile string) ClientParam {
 	return ClientKeyPair(TLSCertFromFiles(certFile, keyFile))
 }
 
-// ClientKeyPair configures the client with the static key pair that it should present to servers when communicating
-// using TLS with client authentication (2-way SSL). If neither ClientKeyPairFiles, ClientKeyPair, nor
-// ClientKeyPairProvider are provided, the client will not present a certificate.
+// ClientKeyPair configures the client with a static key pair sourced from the TLSCertProvider that it should present to
+// servers when communicating using TLS with client authentication (2-way SSL). If neither ClientKeyPairFiles,
+// ClientKeyPair, nor ClientKeyPairProvider are provided, the client will not present a certificate.
 func ClientKeyPair(certProvider TLSCertProvider) ClientParam {
 	return clientParam(certificatesParam(certProvider))
 }

--- a/tlsconfig/tlsconfig_client.go
+++ b/tlsconfig/tlsconfig_client.go
@@ -33,16 +33,24 @@ func (p clientParam) configureClient(cfg *tls.Config) error {
 }
 
 // ClientKeyPairFiles configures the client with the key pair that it should present to servers when communicating using
-// TLS with client authentication (2-way SSL). If this parameter is not provided, the client will not present a
-// certificate.
+// TLS with client authentication (2-way SSL). If neither ClientKeyPairFiles, ClientKeyPair, nor ClientKeyPairProvider
+// are provided, the client will not present a certificate.
 func ClientKeyPairFiles(certFile, keyFile string) ClientParam {
 	return ClientKeyPair(TLSCertFromFiles(certFile, keyFile))
 }
 
-// ClientKeyPair configures the client with the key pair that it should present to servers when communicating using TLS
-// with client authentication (2-way SSL). If this parameter is not provided, the client will not present a certificate.
+// ClientKeyPair configures the client with the static key pair that it should present to servers when communicating
+// using TLS with client authentication (2-way SSL). If neither ClientKeyPairFiles, ClientKeyPair, nor
+// ClientKeyPairProvider are provided, the client will not present a certificate.
 func ClientKeyPair(certProvider TLSCertProvider) ClientParam {
-	return clientParam(authKeyPairParam(certProvider))
+	return clientParam(certificatesParam(certProvider))
+}
+
+// ClientKeyPairProvider configures the client to call the given TLSCertProvider whenever a key pair is requested while
+// communicating with client authentication (2-way SSL). If neither ClientKeyPairFiles, ClientKeyPair, nor
+// ClientKeyPairProvider are provided, the client will not present a certificate.
+func ClientKeyPairProvider(certProvider TLSCertProvider) ClientParam {
+	return clientParam(getClientCertificateParam(certProvider))
 }
 
 // ClientRootCAFiles configures the client with the CA certificates used to verify the certificates provided by servers.

--- a/tlsconfig/tlsconfig_client.go
+++ b/tlsconfig/tlsconfig_client.go
@@ -33,23 +33,16 @@ func (p clientParam) configureClient(cfg *tls.Config) error {
 }
 
 // ClientKeyPairFiles configures the client with the key pair that it should present to servers when communicating using
-// TLS with client authentication (2-way SSL). If neither ClientKeyPairFiles, ClientKeyPair, nor ClientKeyPairProvider
-// are provided, the client will not present a certificate.
+// TLS with client authentication (2-way SSL). If neither ClientKeyPairFiles nor ClientKeyPair are provided, the client
+// will not present a certificate.
 func ClientKeyPairFiles(certFile, keyFile string) ClientParam {
 	return ClientKeyPair(TLSCertFromFiles(certFile, keyFile))
 }
 
-// ClientKeyPair configures the client with a static key pair sourced from the TLSCertProvider that it should present to
-// servers when communicating using TLS with client authentication (2-way SSL). If neither ClientKeyPairFiles,
-// ClientKeyPair, nor ClientKeyPairProvider are provided, the client will not present a certificate.
+// ClientKeyPair configures the client to call the provided TLSCertProvider whenever a key pair is requested when
+// communicating with client authentication (2-way SSL). If neither ClientKeyPairFiles nor ClientKeyPair are provided,
+// the client will not present a certificate.
 func ClientKeyPair(certProvider TLSCertProvider) ClientParam {
-	return clientParam(certificatesParam(certProvider))
-}
-
-// ClientKeyPairProvider configures the client to call the given TLSCertProvider whenever a key pair is requested while
-// communicating with client authentication (2-way SSL). If neither ClientKeyPairFiles, ClientKeyPair, nor
-// ClientKeyPairProvider are provided, the client will not present a certificate.
-func ClientKeyPairProvider(certProvider TLSCertProvider) ClientParam {
 	return clientParam(getClientCertificateParam(certProvider))
 }
 

--- a/tlsconfig/tlsconfig_client_test.go
+++ b/tlsconfig/tlsconfig_client_test.go
@@ -19,6 +19,7 @@ func TestNewClientConfig(t *testing.T) {
 		name         string
 		caFiles      []string
 		cipherSuites []uint16
+		certProvider tlsconfig.TLSCertProvider
 	}{
 		{
 			name: "defaults",
@@ -35,10 +36,17 @@ func TestNewClientConfig(t *testing.T) {
 				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 			},
 		},
+		{
+			name: "certProvider specified",
+			certProvider: func() (tls.Certificate, error) {
+				return tls.Certificate{}, nil
+			},
+		},
 	} {
 		cfg, err := tlsconfig.NewClientConfig(
 			tlsconfig.ClientRootCAs(tlsconfig.CertPoolFromCAFiles(currCase.caFiles...)),
 			tlsconfig.ClientCipherSuites(currCase.cipherSuites...),
+			tlsconfig.ClientKeyPairProvider(currCase.certProvider),
 		)
 		require.NoError(t, err)
 		assert.NotNil(t, cfg, "Case %d: %s", currCaseNum, currCase.name)

--- a/tlsconfig/tlsconfig_client_test.go
+++ b/tlsconfig/tlsconfig_client_test.go
@@ -62,6 +62,16 @@ func TestNewClientConfigErrors(t *testing.T) {
 		wantError string
 	}{
 		{
+			name:      "missing certificate file",
+			keyFile:   clientKeyFile,
+			wantError: "failed to load TLS certificate: open : no such file or directory",
+		},
+		{
+			name:      "missing key file",
+			certFile:  clientCertFile,
+			wantError: "failed to load TLS certificate: open : no such file or directory",
+		},
+		{
 			name:     "invalid CA file",
 			certFile: clientCertFile,
 			keyFile:  clientKeyFile,

--- a/tlsconfig/tlsconfig_client_test.go
+++ b/tlsconfig/tlsconfig_client_test.go
@@ -46,7 +46,7 @@ func TestNewClientConfig(t *testing.T) {
 		cfg, err := tlsconfig.NewClientConfig(
 			tlsconfig.ClientRootCAs(tlsconfig.CertPoolFromCAFiles(currCase.caFiles...)),
 			tlsconfig.ClientCipherSuites(currCase.cipherSuites...),
-			tlsconfig.ClientKeyPairProvider(currCase.certProvider),
+			tlsconfig.ClientKeyPair(currCase.certProvider),
 		)
 		require.NoError(t, err)
 		assert.NotNil(t, cfg, "Case %d: %s", currCaseNum, currCase.name)
@@ -61,16 +61,6 @@ func TestNewClientConfigErrors(t *testing.T) {
 		caFiles   []string
 		wantError string
 	}{
-		{
-			name:      "missing certificate file",
-			keyFile:   clientKeyFile,
-			wantError: "failed to load TLS certificate: open : no such file or directory",
-		},
-		{
-			name:      "missing key file",
-			certFile:  clientCertFile,
-			wantError: "failed to load TLS certificate: open : no such file or directory",
-		},
 		{
 			name:     "invalid CA file",
 			certFile: clientCertFile,

--- a/tlsconfig/tlsconfig_server.go
+++ b/tlsconfig/tlsconfig_server.go
@@ -26,7 +26,7 @@ func NewServerConfig(tlsCertProvider TLSCertProvider, params ...ServerParam) (*t
 	if tlsCertProvider == nil {
 		return nil, fmt.Errorf("tlsCertProvider provided to NewServerConfig was nil")
 	}
-	configurers := []configurer{authKeyPairParam(tlsCertProvider)}
+	configurers := []configurer{certificatesParam(tlsCertProvider)}
 	for _, p := range params {
 		configurers = append(configurers, configurer(p.configureServer))
 	}

--- a/tlsconfig/tlsconfig_server.go
+++ b/tlsconfig/tlsconfig_server.go
@@ -26,7 +26,7 @@ func NewServerConfig(tlsCertProvider TLSCertProvider, params ...ServerParam) (*t
 	if tlsCertProvider == nil {
 		return nil, fmt.Errorf("tlsCertProvider provided to NewServerConfig was nil")
 	}
-	configurers := []configurer{certificatesParam(tlsCertProvider)}
+	configurers := []configurer{getCertificateParam(tlsCertProvider)}
 	for _, p := range params {
 		configurers = append(configurers, configurer(p.configureServer))
 	}

--- a/tlsconfig/tlsconfig_server.go
+++ b/tlsconfig/tlsconfig_server.go
@@ -26,7 +26,7 @@ func NewServerConfig(tlsCertProvider TLSCertProvider, params ...ServerParam) (*t
 	if tlsCertProvider == nil {
 		return nil, fmt.Errorf("tlsCertProvider provided to NewServerConfig was nil")
 	}
-	configurers := []configurer{getCertificateParam(tlsCertProvider)}
+	configurers := []configurer{certificatesParam(tlsCertProvider)}
 	for _, p := range params {
 		configurers = append(configurers, configurer(p.configureServer))
 	}

--- a/tlsconfig/tlsconfig_server_test.go
+++ b/tlsconfig/tlsconfig_server_test.go
@@ -57,7 +57,6 @@ func TestNewServerConfig(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.NotNil(t, cfg, "Case %d: %s", currCaseNum, currCase.name)
-		assert.NotNil(t, cfg.GetCertificate, "Case %d: %s", currCaseNum, currCase.name)
 	}
 }
 

--- a/tlsconfig/tlsconfig_server_test.go
+++ b/tlsconfig/tlsconfig_server_test.go
@@ -57,6 +57,7 @@ func TestNewServerConfig(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.NotNil(t, cfg, "Case %d: %s", currCaseNum, currCase.name)
+		assert.NotNil(t, cfg.GetCertificate, "Case %d: %s", currCaseNum, currCase.name)
 	}
 }
 

--- a/tlsconfig/tlsconfig_test.go
+++ b/tlsconfig/tlsconfig_test.go
@@ -33,7 +33,7 @@ func TestUseTLSConfigClientAuthConnection(t *testing.T) {
 		clientParams      []tlsconfig.ClientParam
 	}{
 		{
-			name:              "TLS with client cert required",
+			name:              "TLS with client cert required and static client certs",
 			serverTLSProvider: tlsconfig.TLSCertFromFiles(serverCertFile, serverKeyFile),
 			serverParams: []tlsconfig.ServerParam{
 				tlsconfig.ServerClientAuthType(tls.RequireAndVerifyClientCert),
@@ -41,6 +41,18 @@ func TestUseTLSConfigClientAuthConnection(t *testing.T) {
 			},
 			clientParams: []tlsconfig.ClientParam{
 				tlsconfig.ClientKeyPairFiles(clientCertFile, clientKeyFile),
+				tlsconfig.ClientRootCAs(tlsconfig.CertPoolFromCAFiles(caCertFile)),
+			},
+		},
+		{
+			name:              "TLS with client cert required and client cert provider",
+			serverTLSProvider: tlsconfig.TLSCertFromFiles(serverCertFile, serverKeyFile),
+			serverParams: []tlsconfig.ServerParam{
+				tlsconfig.ServerClientAuthType(tls.RequireAndVerifyClientCert),
+				tlsconfig.ServerClientCAs(tlsconfig.CertPoolFromCAFiles(caCertFile)),
+			},
+			clientParams: []tlsconfig.ClientParam{
+				tlsconfig.ClientKeyPair(tlsconfig.TLSCertFromFiles(clientCertFile, clientKeyFile)),
 				tlsconfig.ClientRootCAs(tlsconfig.CertPoolFromCAFiles(caCertFile)),
 			},
 		},

--- a/tlsconfig/tlsconfig_test.go
+++ b/tlsconfig/tlsconfig_test.go
@@ -56,7 +56,7 @@ func TestUseTLSConfigClientAuthConnection(t *testing.T) {
 			},
 		},
 	} {
-		func() {
+		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				_, _ = fmt.Fprintf(rw, "OK: %s", req.URL.Path)
 			}))
@@ -81,6 +81,6 @@ func TestUseTLSConfigClientAuthConnection(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, "OK: /hello", string(bytes), "Case %d: %s", i, tc.name)
-		}()
+		})
 	}
 }


### PR DESCRIPTION
Golang TLS supports `GetClientCertificate` in tls config, which calls a function when a certificate is requested instead of serving a static certificate. We change the `ClientKeyPair` param to use this field instead of setting a static certificate. `ClientKeyPairFiles` remains static. This enables users to refresh their certificates so they don't expire.

Comments have been updated to clarify the differences between params.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/194)
<!-- Reviewable:end -->
