### PR TITLE
Make tls.InsecureSkipVerify configurable.

### DIFF
--- a/tlsconfig/tlsconfig_client.go
+++ b/tlsconfig/tlsconfig_client.go
@@ -73,7 +73,10 @@ func ClientCipherSuites(cipherSuites ...uint16) ClientParam {
 	return clientParam(cipherSuitesParam(cipherSuites...))
 }
 
-func InsecureSkipVerify() ClientParam {
+// ClientInsecureSkipVerify sets the InsecureSkipVerify field of tls Config to true. The default value for this field
+// is false. Usage of this option is discouraged and should only be used in limited off-roading cases where the client
+// has no reasonable way of trusting the server.
+func ClientInsecureSkipVerify() ClientParam {
 	return clientParam(func(cfg *tls.Config) error {
 		cfg.InsecureSkipVerify = true
 		return nil

--- a/tlsconfig/tlsconfig_client.go
+++ b/tlsconfig/tlsconfig_client.go
@@ -72,3 +72,10 @@ func ClientRootCAs(certPoolProvider CertPoolProvider) ClientParam {
 func ClientCipherSuites(cipherSuites ...uint16) ClientParam {
 	return clientParam(cipherSuitesParam(cipherSuites...))
 }
+
+func InsecureSkipVerify() ClientParam {
+	return clientParam(func(cfg *tls.Config) error {
+		cfg.InsecureSkipVerify = true
+		return nil
+	})
+}

--- a/tlsconfig/tlsconfig_client_test.go
+++ b/tlsconfig/tlsconfig_client_test.go
@@ -46,7 +46,7 @@ func TestNewClientConfig(t *testing.T) {
 }
 
 func TestNewClientConfigInsecureSkipVerify(t *testing.T) {
-	cfg, err := tlsconfig.NewClientConfig(tlsconfig.InsecureSkipVerify())
+	cfg, err := tlsconfig.NewClientConfig(tlsconfig.ClientInsecureSkipVerify())
 	assert.NoError(t, err)
 	assert.True(t, cfg.InsecureSkipVerify)
 }

--- a/tlsconfig/tlsconfig_client_test.go
+++ b/tlsconfig/tlsconfig_client_test.go
@@ -45,6 +45,12 @@ func TestNewClientConfig(t *testing.T) {
 	}
 }
 
+func TestNewClientConfigInsecureSkipVerify(t *testing.T) {
+	cfg, err := tlsconfig.NewClientConfig(tlsconfig.InsecureSkipVerify())
+	assert.NoError(t, err)
+	assert.True(t, cfg.InsecureSkipVerify)
+}
+
 func TestNewClientConfigErrors(t *testing.T) {
 	for currCaseNum, currCase := range []struct {
 		name      string


### PR DESCRIPTION

It is currently not possible to use the tlsconfig package without requiring secure TLS. Surfacing this option enables rare but necessary off-roading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/203)
<!-- Reviewable:end -->
