### PR TITLE
metrics: Use strings.Builder in toMetricTagsID

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -5,7 +5,6 @@
 package metrics
 
 import (
-	"bytes"
 	"context"
 	"sort"
 	"strings"
@@ -380,14 +379,14 @@ func toMetricTagsID(name string, tags Tags) metricTagsID {
 	for _, t := range tags {
 		bufSize += len(t.keyValue) + 1 // 1 for separator
 	}
-
-	buf := bytes.NewBuffer(make([]byte, 0, bufSize))
+	buf := strings.Builder{}
+	buf.Grow(bufSize)
 	_, _ = buf.WriteString(name)
 	for _, tag := range tags {
 		_, _ = buf.WriteRune('|')
 		_, _ = buf.WriteString(tag.keyValue)
 	}
-	return metricTagsID(buf.Bytes())
+	return metricTagsID(buf.String())
 }
 
 // newSortedTags copies the tag slice before sorting so that in-place mutation does not affect the input slice.


### PR DESCRIPTION
```
// new
BenchmarkRegisterMetric
BenchmarkRegisterMetric/1_tag
BenchmarkRegisterMetric/1_tag-16         	 4665692	       239.6 ns/op	      96 B/op	       3 allocs/op
BenchmarkRegisterMetric/10_tag
BenchmarkRegisterMetric/10_tag-16        	 2098387	       573.9 ns/op	     616 B/op	       3 allocs/op
BenchmarkRegisterMetric/100_tag
BenchmarkRegisterMetric/100_tag-16       	  106561	     11235 ns/op	    6168 B/op	       3 allocs/op
// old
BenchmarkRegisterMetric
BenchmarkRegisterMetric/1_tag
BenchmarkRegisterMetric/1_tag-16         	 3992419	       276.9 ns/op	     120 B/op	       4 allocs/op
BenchmarkRegisterMetric/10_tag
BenchmarkRegisterMetric/10_tag-16        	 1766430	       668.3 ns/op	     728 B/op	       4 allocs/op
BenchmarkRegisterMetric/100_tag
BenchmarkRegisterMetric/100_tag-16       	  118381	     10329 ns/op	    7448 B/op	       4 allocs/op
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/219)
<!-- Reviewable:end -->
