### PR TITLE
metrics: Lazily instantiate Histogram Sample

### DIFF
--- a/metrics/benchmark_test.go
+++ b/metrics/benchmark_test.go
@@ -67,3 +67,42 @@ func doRegisterBench(b *testing.B, n int) {
 		reg.Counter("metricName").Inc(1)
 	}
 }
+
+func BenchmarkHistogram(b *testing.B) {
+	reg := NewRootMetricsRegistry()
+	b.Run("HistogramWithSample with cached Tag", func(b *testing.B) {
+		s := DefaultSample()
+		t := MustNewTag("key", "value")
+		for i := 0; i < b.N; i++ {
+			reg.HistogramWithSample(b.Name(), s, t).Update(int64(i))
+		}
+		b.ReportAllocs()
+	})
+	b.Run("Histogram with cached Tag", func(b *testing.B) {
+		t := MustNewTag("key", "value")
+		for i := 0; i < b.N; i++ {
+			reg.Histogram(b.Name(), t).Update(int64(i))
+		}
+		b.ReportAllocs()
+	})
+	b.Run("HistogramWithSample with NewTag", func(b *testing.B) {
+		s := DefaultSample()
+		for i := 0; i < b.N; i++ {
+			reg.HistogramWithSample(b.Name(), s, MustNewTag("key", "value")).Update(int64(i))
+		}
+		b.ReportAllocs()
+	})
+	b.Run("Histogram with NewTag", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			reg.Histogram(b.Name(), MustNewTag("key", "value")).Update(int64(i))
+		}
+		b.ReportAllocs()
+	})
+	b.Run("cached Histogram", func(b *testing.B) {
+		h := reg.Histogram(b.Name(), MustNewTag("key", "value"))
+		for i := 0; i < b.N; i++ {
+			h.Update(int64(i))
+		}
+		b.ReportAllocs()
+	})
+}

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -331,7 +331,10 @@ func (r *rootRegistry) Timer(name string, tags ...Tag) metrics.Timer {
 }
 
 func (r *rootRegistry) Histogram(name string, tags ...Tag) metrics.Histogram {
-	return r.HistogramWithSample(name, DefaultSample(), tags...)
+	// Use lazy instantiation to avoid allocating a Sample when getting an existing Histogram.
+	return r.registry.GetOrRegister(r.registerMetric(name, tags), func() metrics.Histogram {
+		return metrics.NewHistogram(DefaultSample())
+	}).(metrics.Histogram)
 }
 
 func (r *rootRegistry) HistogramWithSample(name string, sample metrics.Sample, tags ...Tag) metrics.Histogram {


### PR DESCRIPTION
Currently, calling registry.Histogram(...) allocates a DefaultSample() on every call. The underlying gometrics library supports lazy instantiation on the histogram itself (which is used in GetOrRegisterHistogram) but not the Sample.

This PR updates our implementation to use GetOrRegister directly, deferring sample creation to when the registry decides to allocate a new metric object.

Benchmark comparison:
```
name                                              old time/op    new time/op    delta
Histogram/Histogram_with_cached_Tag-16              3.25µs ± 1%    0.73µs ± 2%  -77.42%  (p=0.000 n=11+10)
Histogram/Histogram_with_NewTag-16                  3.55µs ± 1%    1.01µs ± 2%  -71.62%  (p=0.000 n=12+10)

name                                              old alloc/op   new alloc/op   delta
Histogram/Histogram_with_cached_Tag-16              18.8kB ± 0%     0.2kB ± 0%  -99.02%  (p=0.000 n=12+11)
Histogram/Histogram_with_NewTag-16                  18.8kB ± 0%     0.2kB ± 0%  -98.91%  (p=0.000 n=12+11)

name                                              old allocs/op  new allocs/op  delta
Histogram/Histogram_with_cached_Tag-16                8.00 ± 0%      4.00 ± 0%  -50.00%  (p=0.000 n=12+11)
Histogram/Histogram_with_NewTag-16                    11.0 ± 0%       7.0 ± 0%  -36.36%  (p=0.000 n=12+11)
```

Benchmark output on this branch:
```
BenchmarkHistogram
BenchmarkHistogram/cached_Histogram
BenchmarkHistogram/cached_Histogram-16                            	 3912604	       299.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkHistogram/HistogramWithSample_with_cached_Tag
BenchmarkHistogram/HistogramWithSample_with_cached_Tag-16         	 1531075	       784.1 ns/op	     208 B/op	       5 allocs/op
BenchmarkHistogram/Histogram_with_cached_Tag
BenchmarkHistogram/Histogram_with_cached_Tag-16                   	 1646476	       734.8 ns/op	     184 B/op	       4 allocs/op
BenchmarkHistogram/HistogramWithSample_with_NewTag
BenchmarkHistogram/HistogramWithSample_with_NewTag-16             	 1000000	      1041 ns/op	     229 B/op	       8 allocs/op
BenchmarkHistogram/Histogram_with_NewTag
BenchmarkHistogram/Histogram_with_NewTag-16                       	 1000000	      1003 ns/op	     205 B/op	       7 allocs/op
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/227)
<!-- Reviewable:end -->
