### PR TITLE
Update all go.mod Go directives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run: go version
       - run: go run .circleci/generate.go -repoRoot .
-      - run: diff  <(cat .circleci/config.yml) <(go run .circleci/generate.go .)
+      - run: diff  <(cat .circleci/config.yml) <(go run .circleci/generate.go -repoRoot .)
   circle-all:
     docker:
       - image: "golang:1.17.5"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - checkout
       - run: go version
-      - run: go run .circleci/generate.go .
+      - run: go run .circleci/generate.go -repoRoot .
       - run: diff  <(cat .circleci/config.yml) <(go run .circleci/generate.go .)
   circle-all:
     docker:

--- a/.circleci/generate.go
+++ b/.circleci/generate.go
@@ -45,7 +45,7 @@ jobs:
       - checkout
       - run: go version
       - run: go run .circleci/generate.go -repoRoot .
-      - run: diff  <(cat .circleci/config.yml) <(go run .circleci/generate.go .)
+      - run: diff  <(cat .circleci/config.yml) <(go run .circleci/generate.go -repoRoot .)
   circle-all:
     docker:
       - image: "golang:{{.CurrGoVersion}}"

--- a/.circleci/generate.go
+++ b/.circleci/generate.go
@@ -44,7 +44,7 @@ jobs:
     steps:
       - checkout
       - run: go version
-      - run: go run .circleci/generate.go .
+      - run: go run .circleci/generate.go -repoRoot .
       - run: diff  <(cat .circleci/config.yml) <(go run .circleci/generate.go .)
   circle-all:
     docker:


### PR DESCRIPTION
This change is a flup from #229 to update all Go directives for every module. The Go versions used in CircleCI are managed in the [.circleci/generate.go](https://github.com/palantir/pkg/blob/master/.circleci/generate.go) file, but the go directives for all modules were not updated which meant the versions could fall behind what is used in Circle.

One thing to consider is that this repo is currently taking managed Go version updates via excavator (#217) however the CircleCI config does not leverage this. The excavator check also updates all of the go directives, so we may want to disable this repo from the managed Go version check in favor of using this generate script, at least until we converge on a single approach for multi-module management.

This PR also updates the usage of the command to use flags instead of just arguments so that the module updates are conditionally run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/230)
<!-- Reviewable:end -->
