### PR TITLE
fix: Safely handle undef context Done channel in retrier.

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -167,6 +167,11 @@ func WithRandomizationFactor(randomizationFactor float64) Option {
 // If the provided context is canceled (see Context.Done), then Next() will eagerly return false and
 // the retry loop will do no iterations.
 func Start(ctx context.Context, opts ...Option) Retrier {
+	ctxDone := ctx.Done()
+	if ctxDone == nil {
+		ctxDone = make(chan struct{})
+	}
+
 	r := &retrier{
 		options: options{
 			maxAttempts:         defaultMaxAttempts,
@@ -175,7 +180,7 @@ func Start(ctx context.Context, opts ...Option) Retrier {
 			multiplier:          defaultMultiplier,
 			randomizationFactor: defaultRandomizationFactor,
 		},
-		ctxDoneChan:    ctx.Done(),
+		ctxDoneChan:    ctxDone,
 		currentAttempt: 0,
 		isReset:        false,
 	}


### PR DESCRIPTION
### Before this PR
In one of our internal services, we are hitting a panic case where the returned `ctx.Done()` channel is undefined. 
```
panic: interface conversion: interface {} is , not chan struct {}

goroutine 55848 [running]:
context.(*cancelCtx).Done(0xc000074800?)
        /usr/local/go/src/context/context.go:361 +0x1d4
github.com/palantir/pkg/retry.Start({0xd212e0?, 0xc0007f2d20?}, {0xc000501ca0, 0x2, 0xb898e0?})
        /go/src/<REDACT>/sls-status-reporter/vendor/github.com/palantir/pkg/retry/retry.go:178 +0x35
github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient.RetryParams.Start({0xc0003c6920?, 0x0?}, {0xd212e0?, 0xc0007f2d20?})
        /go/src/<REDACT>/sls-status-reporter/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal/refreshingclient/retry.go:38 +0x86
```






### After this PR
As of writing this PR, it isn't clear to me why the Done channel here is undefined. Given this panic occurs from the usage of the retrier in the CGR's [client](https://github.com/palantir/conjure-go-runtime/blob/013ae087b834c7910b7cc87b2ef00e7ab9b8d41b/conjure-go-client/httpclient/client.go#L100) I can maybe see the `Do()` request being canceled before the retrier can be instantiated? Regardless this PR ensures the Done channel is always defined.

==COMMIT_MSG==
Safely handle undef context Done channel in retrier.
==COMMIT_MSG==

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/261)
<!-- Reviewable:end -->
