### PR TITLE
Update gittest to ignore system and global settings

### DIFF
--- a/gittest/gittest.go
+++ b/gittest/gittest.go
@@ -6,6 +6,7 @@ package gittest
 
 import (
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"runtime/debug"
 	"testing"
@@ -45,6 +46,7 @@ func Merge(t *testing.T, gitDir, branch string) {
 func RunGitCommand(t *testing.T, gitDir string, args ...string) string {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = gitDir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_SYSTEM=''", "GIT_CONFIG_GLOBAL=''")
 	output, err := cmd.CombinedOutput()
 	requireNoError(t, err, string(output))
 	return string(output)


### PR DESCRIPTION
Currently, gittest functions in a way that inherits any values set in the system or user global git configuration. For users who have settings which force GPG signing on commits and tags, this makes running local tests impractical, as tests will fail without user actions during the test.

By ignoring any system and global settings, we'll force users to acknowledge any local configuration that is depended on and require it to be set up during the test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/297)
<!-- Reviewable:end -->
