### PR TITLE
improvement: Use go1.21's slices package to avoid allocation in sorting

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -6,7 +6,6 @@ package metrics
 
 import (
 	"context"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -269,7 +268,7 @@ func (r *rootRegistry) Each(f MetricVisitor) {
 		sortedMetricIDs = append(sortedMetricIDs, name)
 		allMetrics[name] = metric
 	})
-	sort.Strings(sortedMetricIDs)
+	sortStrings(sortedMetricIDs)
 
 	for _, id := range sortedMetricIDs {
 		r.idToMetricMutex.RLock()
@@ -401,6 +400,6 @@ func toMetricTagsID(name string, tags Tags) metricTagsID {
 // newSortedTags copies the tag slice before sorting so that in-place mutation does not affect the input slice.
 func newSortedTags(tags Tags) Tags {
 	tagsCopy := append(tags[:0:0], tags...)
-	sort.Sort(tagsCopy)
+	sortTags(tagsCopy)
 	return tagsCopy
 }

--- a/metrics/sort.go
+++ b/metrics/sort.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !go1.21
+
+package metrics
+
+import (
+	"sort"
+)
+
+// sortStrings is the default sort.Strings function.
+// Unfortunately this forces the slice to escape to the heap.
+// See https://github.com/golang/go/issues/17332
+// Go 1.21's slices package does not have this issue.
+var sortStrings = sort.Strings
+
+// sortTags is the default sort.Sort function.
+// Unfortunately this forces the slice to escape to the heap.
+// See https://github.com/golang/go/issues/17332
+// Go 1.21's slices package does not have this issue.
+var sortTags = sort.Sort

--- a/metrics/sort_go121.go
+++ b/metrics/sort_go121.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.21
+
+package metrics
+
+import (
+	"slices"
+)
+
+// sortStrings is the default slices.Sort function which does not force allocation like sort.Strings.
+var sortStrings = slices.Sort[[]string]
+
+// sortTags uses slices.SortFunc which does not force allocation like sort.Sort.
+func sortTags(tags Tags) {
+	slices.SortFunc(tags, compareTags)
+}
+
+func compareTags(a, b Tag) int {
+	switch {
+	case a.keyValue > b.keyValue:
+		return 1
+	case a.keyValue == b.keyValue:
+		return 0
+	default:
+		return -1
+	}
+}


### PR DESCRIPTION
```
pkg: github.com/palantir/pkg/metrics
                                                 │   old.txt    │               new.txt               │
                                                 │    sec/op    │   sec/op     vs base                │
RegisterMetric/1_tag-10                            119.80n ± 2%   94.67n ± 1%  -20.98% (p=0.000 n=10)
RegisterMetric/10_tag-10                            278.8n ± 0%   266.6n ± 1%   -4.36% (p=0.000 n=10)
RegisterMetric/100_tag-10                           5.065µ ± 1%   6.884µ ± 0%  +35.93% (p=0.000 n=10)
Histogram/HistogramWithSample_with_cached_Tag-10    283.9n ± 1%   261.8n ± 0%   -7.78% (p=0.000 n=10)
Histogram/Histogram_with_cached_Tag-10              269.3n ± 1%   242.7n ± 0%   -9.88% (p=0.000 n=10)
Histogram/HistogramWithSample_with_NewTag-10        394.9n ± 1%   376.5n ± 1%   -4.67% (p=0.000 n=10)
Histogram/Histogram_with_NewTag-10                  379.4n ± 0%   352.0n ± 0%   -7.22% (p=0.000 n=10)
Histogram/cached_Histogram-10                       129.4n ± 0%   126.3n ± 0%   -2.40% (p=0.000 n=10)
geomean                                             354.7n        341.5n        -3.74%

                                                 │    old.txt     │                new.txt                 │
                                                 │      B/op      │     B/op      vs base                  │
RegisterMetric/1_tag-10                              96.00 ± 0%       72.00 ± 0%  -25.00% (p=0.000 n=10)
RegisterMetric/10_tag-10                             616.0 ± 0%       592.0 ± 0%   -3.90% (p=0.000 n=10)
RegisterMetric/100_tag-10                          6.023Ki ± 0%     6.000Ki ± 0%   -0.39% (p=0.000 n=10)
Histogram/HistogramWithSample_with_cached_Tag-10     208.0 ± 0%       184.0 ± 0%  -11.54% (p=0.000 n=10)
Histogram/Histogram_with_cached_Tag-10               184.0 ± 0%       160.0 ± 0%  -13.04% (p=0.000 n=10)
Histogram/HistogramWithSample_with_NewTag-10         229.0 ± 0%       205.0 ± 0%  -10.48% (p=0.000 n=10)
Histogram/Histogram_with_NewTag-10                   205.0 ± 0%       181.0 ± 0%  -11.71% (p=0.000 n=10)
Histogram/cached_Histogram-10                        0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                                         ²                  -9.84%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                 │   old.txt    │               new.txt                │
                                                 │  allocs/op   │ allocs/op   vs base                  │
RegisterMetric/1_tag-10                            3.000 ± 0%     2.000 ± 0%  -33.33% (p=0.000 n=10)
RegisterMetric/10_tag-10                           3.000 ± 0%     2.000 ± 0%  -33.33% (p=0.000 n=10)
RegisterMetric/100_tag-10                          3.000 ± 0%     2.000 ± 0%  -33.33% (p=0.000 n=10)
Histogram/HistogramWithSample_with_cached_Tag-10   5.000 ± 0%     4.000 ± 0%  -20.00% (p=0.000 n=10)
Histogram/Histogram_with_cached_Tag-10             4.000 ± 0%     3.000 ± 0%  -25.00% (p=0.000 n=10)
Histogram/HistogramWithSample_with_NewTag-10       8.000 ± 0%     7.000 ± 0%  -12.50% (p=0.000 n=10)
Histogram/Histogram_with_NewTag-10                 7.000 ± 0%     6.000 ± 0%  -14.29% (p=0.000 n=10)
Histogram/cached_Histogram-10                      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                                       ²               -22.26%                ²
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/323)
<!-- Reviewable:end -->
