### PR TITLE
improvement: Drop keyValue field in metrics.Tag; normalizeTag short-circuits simple strings

### DIFF
--- a/metrics/benchmark_test.go
+++ b/metrics/benchmark_test.go
@@ -33,6 +33,19 @@ func BenchmarkNewTag(b *testing.B) {
 	}
 }
 
+func BenchmarkNormalizeTag(b *testing.B) {
+	for _, val := range []string{
+		"a❌Long❌Tag❌With❌Emoji❌Chars",
+		"a Long Tag With Space Chars",
+		"aLongTagValueWithUpperChars",
+		"alongtagvaluewithnospecials",
+		"UPPER",
+		"lower",
+	} {
+		b.Run(val, newTagBenchFunc("key", val))
+	}
+}
+
 func newTagBenchFunc(tagKey, tagValue string) func(*testing.B) {
 	return func(b *testing.B) {
 		b.ReportAllocs()

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -251,7 +251,7 @@ func (r *rootRegistry) Subregistry(prefix string, tags ...Tag) Registry {
 	}
 	return &childRegistry{
 		prefix: prefix,
-		tags:   Tags(tags),
+		tags:   tags,
 		root:   r,
 	}
 }
@@ -385,14 +385,16 @@ func toMetricTagsID(name string, tags Tags) metricTagsID {
 	// calculate how large to make our byte buffer below
 	bufSize := len(name)
 	for _, t := range tags {
-		bufSize += len(t.keyValue) + 1 // 1 for separator
+		bufSize += len(t.key) + len(t.value) + 2 // 2 for separators
 	}
 	buf := strings.Builder{}
 	buf.Grow(bufSize)
 	_, _ = buf.WriteString(name)
 	for _, tag := range tags {
 		_, _ = buf.WriteRune('|')
-		_, _ = buf.WriteString(tag.keyValue)
+		_, _ = buf.WriteString(tag.key)
+		_, _ = buf.WriteRune(':')
+		_, _ = buf.WriteString(tag.value)
 	}
 	return metricTagsID(buf.String())
 }

--- a/metrics/sort_go121.go
+++ b/metrics/sort_go121.go
@@ -20,11 +20,15 @@ func sortTags(tags Tags) {
 
 func compareTags(a, b Tag) int {
 	switch {
-	case a.keyValue > b.keyValue:
-		return 1
-	case a.keyValue == b.keyValue:
-		return 0
-	default:
+	case a.key < b.key:
 		return -1
+	case a.key > b.key:
+		return 1
+	case a.value < b.value:
+		return -1
+	case a.value > b.value:
+		return 1
+	default:
+		return 0
 	}
 }

--- a/metrics/tag.go
+++ b/metrics/tag.go
@@ -18,8 +18,6 @@ import (
 type Tag struct {
 	key   string
 	value string
-	// Store the concatenated key and value so we don't need to reconstruct it in String() (used in toMetricTagID)
-	keyValue string
 }
 
 func (t Tag) Key() string {
@@ -32,7 +30,7 @@ func (t Tag) Value() string {
 
 // The full representation of the tag, which is "key:value".
 func (t Tag) String() string {
-	return t.keyValue
+	return t.key + ":" + t.value
 }
 
 type Tags []Tag
@@ -61,7 +59,10 @@ func (t Tags) Len() int {
 }
 
 func (t Tags) Less(i, j int) bool {
-	return t[i].keyValue < t[j].keyValue
+	if t[i].key == t[j].key {
+		return t[i].value < t[j].value
+	}
+	return t[i].key < t[j].key
 }
 
 func (t Tags) Swap(i, j int) {
@@ -118,9 +119,8 @@ func newTag(k, v string) Tag {
 	normalizedKey := normalizeTag(k, validKeyChars)
 	normalizedValue := normalizeTag(v, validValueChars)
 	return Tag{
-		key:      normalizedKey,
-		value:    normalizedValue,
-		keyValue: normalizedKey + ":" + normalizedValue,
+		key:   normalizedKey,
+		value: normalizedValue,
 	}
 }
 

--- a/metrics/tag.go
+++ b/metrics/tag.go
@@ -180,6 +180,17 @@ func init() {
 //
 // Note that this function does not impose the length restriction described above.
 func normalizeTag(in string, validChars [utf8.RuneSelf]bool) string {
+	foundSpecial := false
+	for _, r := range in {
+		if r >= utf8.RuneSelf || !validChars[r] {
+			foundSpecial = true
+			break
+		}
+	}
+	if !foundSpecial {
+		return in
+	}
+
 	var builder strings.Builder
 	builder.Grow(len(in))
 	for _, r := range in {

--- a/metrics/tag_test.go
+++ b/metrics/tag_test.go
@@ -16,9 +16,8 @@ func TestMustTag(t *testing.T) {
 		actual, err := NewTag("keyWithUpper", "valueWithUpper")
 		assert.NoError(t, err)
 		assert.Equal(t, Tag{
-			key:      "keywithupper",
-			value:    "valuewithupper",
-			keyValue: "keywithupper:valuewithupper",
+			key:   "keywithupper",
+			value: "valuewithupper",
 		},
 			actual)
 	})
@@ -27,9 +26,8 @@ func TestMustTag(t *testing.T) {
 		actual, err := NewTag("a_-./0", "a_-:./0")
 		assert.NoError(t, err)
 		assert.Equal(t, Tag{
-			key:      "a_-./0",
-			value:    "a_-:./0",
-			keyValue: "a_-./0:a_-:./0",
+			key:   "a_-./0",
+			value: "a_-:./0",
 		},
 			actual)
 	})
@@ -38,9 +36,8 @@ func TestMustTag(t *testing.T) {
 		actual, err := NewTag("a(❌)", "a(❌)")
 		assert.NoError(t, err)
 		assert.Equal(t, Tag{
-			key:      "a___",
-			value:    "a___",
-			keyValue: "a___:a___",
+			key:   "a___",
+			value: "a___",
 		},
 			actual)
 	})


### PR DESCRIPTION
```
pkg: github.com/palantir/pkg/metrics
                                                 │   old.txt    │              new.txt               │
                                                 │    sec/op    │   sec/op     vs base               │
NewTag/tagLen:2-10                                  59.86n ± 2%   12.11n ± 1%  -79.77% (p=0.001 n=7)
NewTag/tagLen:10-10                                 91.77n ± 1%   15.65n ± 1%  -82.95% (p=0.001 n=7)
NewTag/tagLen:100-10                               414.10n ± 1%   83.79n ± 1%  -79.77% (p=0.001 n=7)
NewTag/tagLen:199-10                                745.8n ± 2%   174.2n ± 1%  -76.64% (p=0.001 n=7)
NormalizeTag/a❌Long❌Tag❌With❌Emoji❌Chars-10    273.6n ± 3%   223.8n ± 1%  -18.20% (p=0.001 n=7)
NormalizeTag/a_Long_Tag_With_Space_Chars-10         195.3n ± 1%   145.7n ± 1%  -25.40% (p=0.001 n=7)
NormalizeTag/aLongTagValueWithUpperChars-10         168.5n ± 1%   118.1n ± 1%  -29.91% (p=0.001 n=7)
NormalizeTag/alongtagvaluewithnospecials-10        169.10n ± 1%   30.06n ± 1%  -82.22% (p=0.001 n=7)
NormalizeTag/UPPER-10                               90.60n ± 1%   40.59n ± 1%  -55.20% (p=0.001 n=7)
NormalizeTag/lower-10                               90.50n ± 0%   14.40n ± 1%  -84.09% (p=0.001 n=7)
RegisterMetric/1_tag-10                             93.79n ± 1%   99.51n ± 1%   +6.10% (p=0.001 n=7)
RegisterMetric/10_tag-10                            265.7n ± 1%   305.2n ± 2%  +14.87% (p=0.001 n=7)
RegisterMetric/100_tag-10                           6.866µ ± 2%   5.579µ ± 2%  -18.74% (p=0.001 n=7)
Histogram/HistogramWithSample_with_cached_Tag-10    263.8n ± 1%   263.9n ± 1%        ~ (p=0.925 n=7)
Histogram/Histogram_with_cached_Tag-10              244.1n ± 1%   242.8n ± 1%        ~ (p=0.119 n=7)
Histogram/HistogramWithSample_with_NewTag-10        378.8n ± 1%   287.4n ± 1%  -24.13% (p=0.001 n=7)
Histogram/Histogram_with_NewTag-10                  353.3n ± 4%   263.8n ± 4%  -25.33% (p=0.001 n=7)
Histogram/cached_Histogram-10                       126.6n ± 1%   127.5n ± 1%        ~ (p=0.156 n=7)
geomean                                             232.5n        118.0n       -49.26%

                                                 │    old.txt     │                 new.txt                  │
                                                 │      B/op      │     B/op      vs base                    │
NewTag/tagLen:2-10                                   5.000 ± 0%       0.000 ± 0%  -100.00% (p=0.001 n=7)
NewTag/tagLen:10-10                                  24.00 ± 0%        0.00 ± 0%  -100.00% (p=0.001 n=7)
NewTag/tagLen:100-10                                 240.0 ± 0%         0.0 ± 0%  -100.00% (p=0.001 n=7)
NewTag/tagLen:199-10                                 432.0 ± 0%         0.0 ± 0%  -100.00% (p=0.001 n=7)
NormalizeTag/a❌Long❌Tag❌With❌Emoji❌Chars-10     83.00 ± 0%       48.00 ± 0%   -42.17% (p=0.001 n=7)
NormalizeTag/a_Long_Tag_With_Space_Chars-10          67.00 ± 0%       32.00 ± 0%   -52.24% (p=0.001 n=7)
NormalizeTag/aLongTagValueWithUpperChars-10          67.00 ± 0%       32.00 ± 0%   -52.24% (p=0.001 n=7)
NormalizeTag/alongtagvaluewithnospecials-10          67.00 ± 0%        0.00 ± 0%  -100.00% (p=0.001 n=7)
NormalizeTag/UPPER-10                               21.000 ± 0%       5.000 ± 0%   -76.19% (p=0.001 n=7)
NormalizeTag/lower-10                                21.00 ± 0%        0.00 ± 0%  -100.00% (p=0.001 n=7)
RegisterMetric/1_tag-10                              72.00 ± 0%       56.00 ± 0%   -22.22% (p=0.001 n=7)
RegisterMetric/10_tag-10                             592.0 ± 0%       432.0 ± 0%   -27.03% (p=0.001 n=7)
RegisterMetric/100_tag-10                          6.000Ki ± 0%     4.375Ki ± 0%   -27.08% (p=0.001 n=7)
Histogram/HistogramWithSample_with_cached_Tag-10     184.0 ± 0%       152.0 ± 0%   -17.39% (p=0.001 n=7)
Histogram/Histogram_with_cached_Tag-10               160.0 ± 0%       128.0 ± 0%   -20.00% (p=0.001 n=7)
Histogram/HistogramWithSample_with_NewTag-10         205.0 ± 0%       152.0 ± 0%   -25.85% (p=0.001 n=7)
Histogram/Histogram_with_NewTag-10                   181.0 ± 0%       128.0 ± 0%   -29.28% (p=0.001 n=7)
Histogram/cached_Histogram-10                        0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=7) ¹
geomean                                                         ²                 ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                                 │   old.txt    │                new.txt                 │
                                                 │  allocs/op   │ allocs/op   vs base                    │
NewTag/tagLen:2-10                                 3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
NewTag/tagLen:10-10                                3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
NewTag/tagLen:100-10                               3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
NewTag/tagLen:199-10                               3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
NormalizeTag/a❌Long❌Tag❌With❌Emoji❌Chars-10   3.000 ± 0%     1.000 ± 0%   -66.67% (p=0.001 n=7)
NormalizeTag/a_Long_Tag_With_Space_Chars-10        3.000 ± 0%     1.000 ± 0%   -66.67% (p=0.001 n=7)
NormalizeTag/aLongTagValueWithUpperChars-10        3.000 ± 0%     1.000 ± 0%   -66.67% (p=0.001 n=7)
NormalizeTag/alongtagvaluewithnospecials-10        3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
NormalizeTag/UPPER-10                              3.000 ± 0%     1.000 ± 0%   -66.67% (p=0.001 n=7)
NormalizeTag/lower-10                              3.000 ± 0%     0.000 ± 0%  -100.00% (p=0.001 n=7)
RegisterMetric/1_tag-10                            2.000 ± 0%     2.000 ± 0%         ~ (p=1.000 n=7) ¹
RegisterMetric/10_tag-10                           2.000 ± 0%     2.000 ± 0%         ~ (p=1.000 n=7) ¹
RegisterMetric/100_tag-10                          2.000 ± 0%     2.000 ± 0%         ~ (p=1.000 n=7) ¹
Histogram/HistogramWithSample_with_cached_Tag-10   4.000 ± 0%     4.000 ± 0%         ~ (p=1.000 n=7) ¹
Histogram/Histogram_with_cached_Tag-10             3.000 ± 0%     3.000 ± 0%         ~ (p=1.000 n=7) ¹
Histogram/HistogramWithSample_with_NewTag-10       7.000 ± 0%     4.000 ± 0%   -42.86% (p=0.001 n=7)
Histogram/Histogram_with_NewTag-10                 6.000 ± 0%     3.000 ± 0%   -50.00% (p=0.001 n=7)
Histogram/cached_Histogram-10                      0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=7) ¹
geomean                                                       ²               ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/324)
<!-- Reviewable:end -->
