### PR TITLE
fix: Remove ciphers considered insecure in go 1.22.

### DIFF
--- a/tlsconfig/common.go
+++ b/tlsconfig/common.go
@@ -97,7 +97,7 @@ func configureTLSConfig(cfgs ...configurer) (*tls.Config, error) {
 	tlsCfg := &tls.Config{
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
-		CipherSuites:             append(defaultCipherSuites, defaultChachaCiphers...),
+		CipherSuites:             defaultCipherSuites,
 		Renegotiation:            tls.RenegotiateNever,
 	}
 	for _, currCfg := range cfgs {

--- a/tlsconfig/common.go
+++ b/tlsconfig/common.go
@@ -12,11 +12,19 @@ import (
 )
 
 var defaultCipherSuites = []uint16{
-	// This cipher suite is included to enable http/2. For details, see
-	// https://blog.bracelab.com/achieving-perfect-ssl-labs-score-with-go
-	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	// TLSv1.3
+	tls.TLS_CHACHA20_POLY1305_SHA256,
+	tls.TLS_AES_128_GCM_SHA256,
+	tls.TLS_AES_256_GCM_SHA384,
+	// TLSv1.2
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	// This cipher suite is included to enable http/2. For details, see
+	// required to include for http/2: https://http2.github.io/http2-spec/#rfc.section.9.2.2
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 }
 
 // TLSCertFromFiles returns a provider that returns a tls.Certificate by loading an X509 key pair from the files in the
@@ -89,7 +97,7 @@ func configureTLSConfig(cfgs ...configurer) (*tls.Config, error) {
 	tlsCfg := &tls.Config{
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
-		CipherSuites:             defaultCipherSuites,
+		CipherSuites:             append(defaultCipherSuites, defaultChachaCiphers...),
 		Renegotiation:            tls.RenegotiateNever,
 	}
 	for _, currCfg := range cfgs {

--- a/tlsconfig/common.go
+++ b/tlsconfig/common.go
@@ -8,7 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 var defaultCipherSuites = []uint16{
@@ -16,9 +16,7 @@ var defaultCipherSuites = []uint16{
 	// https://blog.bracelab.com/achieving-perfect-ssl-labs-score-with-go
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-	tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 }
 
 // TLSCertFromFiles returns a provider that returns a tls.Certificate by loading an X509 key pair from the files in the
@@ -35,7 +33,7 @@ func CertPoolFromCAFiles(caFiles ...string) CertPoolProvider {
 	return func() (*x509.CertPool, error) {
 		certPool := x509.NewCertPool()
 		for _, caFile := range caFiles {
-			cert, err := ioutil.ReadFile(caFile)
+			cert, err := os.ReadFile(caFile)
 			if err != nil {
 				return nil, fmt.Errorf("failed to load certificates from file %s: %v", caFile, err)
 			}


### PR DESCRIPTION
## Before this PR
We included the following ciphers in our set of default ciphers:
- `TLS_RSA_WITH_AES_256_GCM_SHA384`
- `TLS_RSA_WITH_AES_256_CBC_SHA`

## After this PR
In Go 1.22 there ciphers were marked as insecure ([commit](https://github.com/golang/go/commit/dc5a0d276bbcd6120325c9e0f9c8fd099fa2b8d6)). Trying to run a server with these ciphers can result in `unknown cipher` errors. Users can force use these ciphers via `GODEBUG` flags, but we should pre-emptively remove these ciphers as they are now considered insecure.

This PR updates the set of ciphers we use in Go to the current desirable set of cipher-suites. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/340)
<!-- Reviewable:end -->
