### PR TITLE
Add field tags for yaml parsing of yamlpatch.Operation

### DIFF
--- a/yamlpatch/types.go
+++ b/yamlpatch/types.go
@@ -24,10 +24,10 @@ type Patch []Operation
 
 // Operation represents a RFC6902 JSON Patch operation.
 type Operation struct {
-	Type  string      `json:"op"`
-	Path  Path        `json:"path"`
-	From  Path        `json:"from,omitempty"`
-	Value interface{} `json:"value,omitempty"`
+	Type  string      `json:"op" yaml:"op"`
+	Path  Path        `json:"path" yaml:"path"`
+	From  Path        `json:"from,omitempty" yaml:"from,omitempty"`
+	Value interface{} `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 func (op Operation) String() string {


### PR DESCRIPTION
Previously, operations weren't properly yaml-deserializable due to the `Type` field rename.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/341)
<!-- Reviewable:end -->
