### PR TITLE
Add ability to patch yaml with comments

### DIFF
--- a/yamlpatch/container_test.go
+++ b/yamlpatch/container_test.go
@@ -84,7 +84,7 @@ func TestContainers(t *testing.T) {
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Add("newkey", valNode)
 				require.NoError(t, err)
@@ -100,7 +100,7 @@ newkey: newvalue
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode(map[string]interface{}{"bar": "val"})
+				valNode, err := valueToYAMLNode(map[string]interface{}{"bar": "val"}, "")
 				require.NoError(t, err)
 				err = c.Add("foo", valNode)
 				require.NoError(t, err)
@@ -116,7 +116,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Add("foo", valNode)
 				require.EqualError(t, err, "key foo already exists and can not be added")
@@ -131,7 +131,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Set("foo", valNode)
 				require.NoError(t, err)
@@ -144,7 +144,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode(map[string]interface{}{"bar": "update", "baz": 2})
+				valNode, err := valueToYAMLNode(map[string]interface{}{"bar": "update", "baz": 2}, "")
 				require.NoError(t, err)
 				err = c.Set("foo", valNode)
 				require.NoError(t, err)
@@ -160,7 +160,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Set("notfound", valNode)
 				require.EqualError(t, err, "key notfound does not exist and can not be replaced")
@@ -291,7 +291,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Add("-", valNode)
 				require.NoError(t, err)
@@ -311,7 +311,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Add("3", valNode)
 				require.NoError(t, err)
@@ -331,7 +331,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Add("0", valNode)
 				require.NoError(t, err)
@@ -351,7 +351,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Add("1", valNode)
 				require.NoError(t, err)
@@ -368,7 +368,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Add("-", valNode)
 				require.NoError(t, err)
@@ -385,7 +385,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Add("4", valNode)
 				require.EqualError(t, err, "add index key out of bounds (idx 4, len 3)")
@@ -404,7 +404,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Set("1", valNode)
 				require.NoError(t, err)
@@ -423,7 +423,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode(map[string]interface{}{"bar": "update", "baz": 2})
+				valNode, err := valueToYAMLNode(map[string]interface{}{"bar": "update", "baz": 2}, "")
 				require.NoError(t, err)
 				err = c.Set("1", valNode)
 				require.NoError(t, err)
@@ -442,7 +442,7 @@ foo:
 			Patch: func(t *testing.T, node *yaml.Node) {
 				c, err := newContainer(node)
 				require.NoError(t, err)
-				valNode, err := valueToYAMLNode("newvalue")
+				valNode, err := valueToYAMLNode("newvalue", "")
 				require.NoError(t, err)
 				err = c.Set("2", valNode)
 				require.EqualError(t, err, "set index key out of bounds (idx 2, len 2)")

--- a/yamlpatch/patch.go
+++ b/yamlpatch/patch.go
@@ -44,7 +44,7 @@ func Apply(originalBytes []byte, patch Patch) ([]byte, error) {
 		case OperationCopy:
 			err = patchCopy(node, op.Path, op.From)
 		case OperationTest:
-			err = patchTest(node, op.Path, op.Value, op.Comment)
+			err = patchTest(node, op.Path, op.Value)
 		default:
 			err = errors.Errorf("unexpected op")
 		}
@@ -157,7 +157,7 @@ func patchCopy(node *yaml.Node, path Path, from Path) error {
 	return toParent.Add(path.Key(), fromNodeClone)
 }
 
-func patchTest(node *yaml.Node, path Path, testValue interface{}, comment string) error {
+func patchTest(node *yaml.Node, path Path, testValue interface{}) error {
 	_, valueNode, err := getParentAndLeaf(node, path)
 	if err != nil {
 		return err
@@ -169,8 +169,9 @@ func patchTest(node *yaml.Node, path Path, testValue interface{}, comment string
 	if err != nil {
 		return err
 	}
-	// roundtrip test value to use standard type
-	testValueNode, err := valueToYAMLNode(testValue, comment)
+	// roundtrip test value to use standard type, comment is unset since this operation only
+	// looks at the existing value and compares it against the test value
+	testValueNode, err := valueToYAMLNode(testValue, "")
 	if err != nil {
 		return err
 	}

--- a/yamlpatch/patch_test.go
+++ b/yamlpatch/patch_test.go
@@ -84,6 +84,18 @@ foo:
   bar: 1 # my bar`,
 		},
 		{
+			Name:  "add into array",
+			Patch: []string{`{"op":"add","path":"/foo/arr/0","value":0}`},
+			Body: `# my foo
+foo:
+  arr: [1, 2, 3]
+  bar: 1 # my bar`,
+			Expected: `# my foo
+foo:
+  arr: [0, 1, 2, 3]
+  bar: 1 # my bar`,
+		},
+		{
 			Name:  "add to array with comment",
 			Patch: []string{`{"op":"add","path":"/foo/arr/-","value":4,"comment":"the number 4"}`},
 			Body: `# my foo
@@ -104,16 +116,28 @@ foo:
     - 4`,
 		},
 		{
-			Name:  "add into array",
-			Patch: []string{`{"op":"add","path":"/foo/arr/0","value":0}`},
+			Name:  "replace object with comment",
+			Patch: []string{`{"op":"replace","path":"/foo/bar","value":{"key":"value"},"comment":"key value pair"}`},
 			Body: `# my foo
 foo:
-  arr: [1, 2, 3]
-  bar: 1 # my bar`,
+  bar: hello-world # previous comment`,
 			Expected: `# my foo
 foo:
-  arr: [0, 1, 2, 3]
-  bar: 1 # my bar`,
+  bar:
+    # key value pair
+    key: value`,
+		},
+		{
+			Name:  "test object with comment",
+			Patch: []string{`{"op":"replace","path":"/foo/bar","value":{"key":"value"},"comment":"key value pair"}`},
+			Body: `# my foo
+foo:
+  bar: hello-world # previous comment`,
+			Expected: `# my foo
+foo:
+  bar:
+    # key value pair
+    key: value`,
 		},
 		// Test cases from json-patch: https://github.com/evanphx/json-patch/blob/master/patch_test.go to verify JSON Patch correctness.
 		{

--- a/yamlpatch/patch_test.go
+++ b/yamlpatch/patch_test.go
@@ -127,18 +127,6 @@ foo:
     # key value pair
     key: value`,
 		},
-		{
-			Name:  "test object with comment",
-			Patch: []string{`{"op":"replace","path":"/foo/bar","value":{"key":"value"},"comment":"key value pair"}`},
-			Body: `# my foo
-foo:
-  bar: hello-world # previous comment`,
-			Expected: `# my foo
-foo:
-  bar:
-    # key value pair
-    key: value`,
-		},
 		// Test cases from json-patch: https://github.com/evanphx/json-patch/blob/master/patch_test.go to verify JSON Patch correctness.
 		{
 			Name:     "jsonpatch add",

--- a/yamlpatch/patch_test.go
+++ b/yamlpatch/patch_test.go
@@ -84,6 +84,26 @@ foo:
   bar: 1 # my bar`,
 		},
 		{
+			Name:  "add to array with comment",
+			Patch: []string{`{"op":"add","path":"/foo/arr/-","value":4,"comment":"the number 4"}`},
+			Body: `# my foo
+foo:
+  arr:
+    # numbers 1 through 3
+    - 1
+    - 2
+    - 3`,
+			Expected: `# my foo
+foo:
+  arr:
+    # numbers 1 through 3
+    - 1
+    - 2
+    - 3
+    # the number 4
+    - 4`,
+		},
+		{
 			Name:  "add into array",
 			Patch: []string{`{"op":"add","path":"/foo/arr/0","value":0}`},
 			Body: `# my foo

--- a/yamlpatch/types.go
+++ b/yamlpatch/types.go
@@ -28,6 +28,9 @@ type Operation struct {
 	Path  Path        `json:"path" yaml:"path"`
 	From  Path        `json:"from,omitempty" yaml:"from,omitempty"`
 	Value interface{} `json:"value,omitempty" yaml:"value,omitempty"`
+
+	// If not empty, will be inserted as a head comment above this node
+	Comment string `json:"comment,omitempty" yaml:"comment,omitempty"`
 }
 
 func (op Operation) String() string {


### PR DESCRIPTION
This PR updates the `Patch` struct to include a `Comment` field, which is piped to the `HeadComment` field in the generated `yaml.Node` for `Add` and `Replace` operations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/349)
<!-- Reviewable:end -->
