### PR TITLE
refreshables: New constructors for more flexibility in how derivative refreshables are created

### DIFF
--- a/refreshable/refreshable.go
+++ b/refreshable/refreshable.go
@@ -112,13 +112,13 @@ func Validate[T any](original Refreshable[T], validatingFn func(T) error) (Valid
 	return MapWithError(original, identity(validatingFn))
 }
 
-// Merge returns a new Refreshable that combines the latest values of two Refreshables of different types using the reduceFn.
+// Merge returns a new Refreshable that combines the latest values of two Refreshables of different types using the mergeFn.
 // The returned Refreshable is updated whenever either of the original Refreshables updates.
 // The unsubscribe function removes subscriptions from both original Refreshables.
-func Merge[T1 any, T2 any, R any](original1 Refreshable[T1], original2 Refreshable[T2], reduceFn func(T1, T2) R) (Refreshable[R], UnsubscribeFunc) {
+func Merge[T1 any, T2 any, R any](original1 Refreshable[T1], original2 Refreshable[T2], mergeFn func(T1, T2) R) (Refreshable[R], UnsubscribeFunc) {
 	out := newZero[R]()
 	doUpdate := func() {
-		out.Update(reduceFn(original1.Current(), original2.Current()))
+		out.Update(mergeFn(original1.Current(), original2.Current()))
 	}
 	stop1 := original1.Subscribe(func(T1) { doUpdate() })
 	stop2 := original2.Subscribe(func(T2) { doUpdate() })
@@ -128,8 +128,7 @@ func Merge[T1 any, T2 any, R any](original1 Refreshable[T1], original2 Refreshab
 	}
 }
 
-// Collect returns a new Refreshable that combines the latest values of multiple Refreshables using the reduceFn.
-// The reduceFn is called with a slice of the current values of the original Refreshables.
+// Collect returns a new Refreshable that combines the latest values of multiple Refreshables into a slice.
 // The returned Refreshable is updated whenever any of the original Refreshables updates.
 // The unsubscribe function removes subscriptions from all original Refreshables.
 func Collect[T any](list ...Refreshable[T]) (Refreshable[[]T], UnsubscribeFunc) {

--- a/refreshable/refreshable_example_test.go
+++ b/refreshable/refreshable_example_test.go
@@ -156,47 +156,58 @@ func ExampleValidate() {
 	// 100 <nil>
 }
 
-func ExampleReduce() {
+func ExampleMerge() {
 	r1 := refreshable.New(42)
 	r2 := refreshable.New(100)
-	reduced, stop := refreshable.Reduce(func(v1, v2 int) string {
+	merged, stop := refreshable.Merge(r1, r2, func(v1, v2 int) string {
 		return fmt.Sprintf("Sum: %d", v1+v2)
-	}, r1, r2)
-	fmt.Println(reduced.Current())
+	})
+	fmt.Println(merged.Current())
 	r1.Update(50)
-	fmt.Println(reduced.Current())
+	fmt.Println(merged.Current())
 	r2.Update(150)
-	fmt.Println(reduced.Current())
+	fmt.Println(merged.Current())
 	stop()
 	r1.Update(60)
-	fmt.Println(reduced.Current())
+	fmt.Println(merged.Current())
 	// Output: Sum: 142
 	// Sum: 150
 	// Sum: 200
 	// Sum: 200
 }
 
-func ExampleReduceN() {
+func ExampleCollect() {
 	r1 := refreshable.New(10)
 	r2 := refreshable.New(20)
 	r3 := refreshable.New(30)
-	reduced, stop := refreshable.ReduceN(func(vals []int) int {
-		sum := 0
-		for _, v := range vals {
-			sum += v
-		}
-		return sum
-	}, r1, r2, r3)
-	fmt.Println(reduced.Current())
+
+	collected, stop := refreshable.Collect(r1, r2, r3)
+
+	printCollected := func() {
+		values := collected.Current()
+		fmt.Printf("Collected values: %v\n", values)
+	}
+
+	printCollected() // Initial values
+
 	r1.Update(15)
-	fmt.Println(reduced.Current())
+	printCollected() // After updating r1
+
 	r2.Update(25)
-	fmt.Println(reduced.Current())
-	stop()
+	printCollected() // After updating r2
+
 	r3.Update(35)
-	fmt.Println(reduced.Current())
-	// Output: 60
-	// 65
-	// 70
-	// 70
+	printCollected() // After updating r3
+
+	stop() // Stop collecting updates
+
+	r1.Update(40)
+	printCollected() // No change after stopping
+
+	// Output:
+	// Collected values: [10 20 30]
+	// Collected values: [15 20 30]
+	// Collected values: [15 25 30]
+	// Collected values: [15 25 35]
+	// Collected values: [15 25 35]
 }

--- a/refreshable/refreshable_example_test.go
+++ b/refreshable/refreshable_example_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package refreshable_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+
+	"github.com/palantir/pkg/refreshable/v2"
+)
+
+func ExampleNew() {
+	r := refreshable.New(42)
+	fmt.Println(r.Current())
+	// Output: 42
+}
+
+func ExampleUpdatable_Update() {
+	r := refreshable.New(42)
+	r.Update(100)
+	fmt.Println(r.Current())
+	// Output: 100
+}
+
+func ExampleRefreshable_Subscribe() {
+	r := refreshable.New(42)
+	stop := r.Subscribe(func(val int) {
+		fmt.Println("Updated value:", val)
+	})
+	r.Update(100)
+	stop()
+	r.Update(200)
+	// Output: Updated value: 42
+	// Updated value: 100
+}
+
+func ExampleCached() {
+	r := refreshable.New(42)
+	cached, stop := refreshable.Cached(r)
+	cached.Subscribe(func(val int) {
+		fmt.Println("Update:", val)
+	})
+	fmt.Println(cached.Current())
+	r.Update(100)
+	fmt.Println(cached.Current())
+	r.Update(100) // No update
+	stop()
+	r.Update(200)
+	fmt.Println(cached.Current())
+	// Output: Update: 42
+	// 42
+	// Update: 100
+	// 100
+	// 100
+}
+
+func ExampleView() {
+	r := refreshable.New(42)
+	view := refreshable.View(r, func(val int) string {
+		return fmt.Sprintf("Value: %d", val)
+	})
+	fmt.Println(view.Current())
+	r.Update(100)
+	fmt.Println(view.Current())
+	r.Update(100) // Duplicate update
+	fmt.Println(view.Current())
+	// Output: Value: 42
+	// Value: 100
+	// Value: 100
+}
+
+func ExampleMap() {
+	r := refreshable.New(42)
+	mapped, stop := refreshable.Map(r, func(val int) string {
+		return fmt.Sprintf("Mapped: %d", val)
+	})
+	fmt.Println(mapped.Current())
+	r.Update(100)
+	fmt.Println(mapped.Current())
+	stop()
+	r.Update(200)
+	fmt.Println(mapped.Current())
+	// Output: Mapped: 42
+	// Mapped: 100
+	// Mapped: 100
+}
+
+func ExampleMapContext() {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := refreshable.New(42)
+	mapped := refreshable.MapContext(ctx, r, func(val int) string {
+		return fmt.Sprintf("Mapped: %d", val)
+	})
+	fmt.Println(mapped.Current())
+	r.Update(100)
+	fmt.Println(mapped.Current())
+	cancel()
+	runtime.Gosched()
+	r.Update(200)
+	fmt.Println(mapped.Current())
+	// Output: Mapped: 42
+	// Mapped: 100
+	// Mapped: 100
+}
+
+func ExampleMapWithError() {
+	r := refreshable.New(42)
+	validated, stop, err := refreshable.MapWithError(r, func(val int) (string, error) {
+		if val < 50 {
+			return "", fmt.Errorf("invalid: %d", val)
+		}
+		return fmt.Sprintf("Valid: %d", val), nil
+	})
+	if err != nil {
+		fmt.Println("Initial error:", err)
+	}
+	fmt.Println(validated.Validation())
+	r.Update(100)
+	fmt.Println(validated.Validation())
+	r.Update(24)
+	fmt.Println(validated.Validation())
+	stop()
+	r.Update(200)
+	fmt.Println(validated.Validation())
+	// Output: Initial error: invalid: 42
+	//  invalid: 42
+	// Valid: 100 <nil>
+	//  invalid: 24
+	//  invalid: 24
+}
+
+func ExampleValidate() {
+	r := refreshable.New(42)
+	validated, stop, err := refreshable.Validate(r, func(val int) error {
+		if val < 50 {
+			return errors.New("value too low")
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Println("Initial error:", err)
+	}
+	fmt.Println(validated.Validation())
+	r.Update(100)
+	fmt.Println(validated.Validation())
+	stop()
+	r.Update(200)
+	fmt.Println(validated.Validation())
+	// Output: Initial error: value too low
+	// 42 value too low
+	// 100 <nil>
+	// 100 <nil>
+}
+
+func ExampleReduce() {
+	r1 := refreshable.New(42)
+	r2 := refreshable.New(100)
+	reduced, stop := refreshable.Reduce(func(v1, v2 int) string {
+		return fmt.Sprintf("Sum: %d", v1+v2)
+	}, r1, r2)
+	fmt.Println(reduced.Current())
+	r1.Update(50)
+	fmt.Println(reduced.Current())
+	r2.Update(150)
+	fmt.Println(reduced.Current())
+	stop()
+	r1.Update(60)
+	fmt.Println(reduced.Current())
+	// Output: Sum: 142
+	// Sum: 150
+	// Sum: 200
+	// Sum: 200
+}
+
+func ExampleReduceN() {
+	r1 := refreshable.New(10)
+	r2 := refreshable.New(20)
+	r3 := refreshable.New(30)
+	reduced, stop := refreshable.ReduceN(func(vals []int) int {
+		sum := 0
+		for _, v := range vals {
+			sum += v
+		}
+		return sum
+	}, r1, r2, r3)
+	fmt.Println(reduced.Current())
+	r1.Update(15)
+	fmt.Println(reduced.Current())
+	r2.Update(25)
+	fmt.Println(reduced.Current())
+	stop()
+	r3.Update(35)
+	fmt.Println(reduced.Current())
+	// Output: 60
+	// 65
+	// 70
+	// 70
+}


### PR DESCRIPTION
- `Cached()` subscribes to an upstream refreshable and stores the result in one it creates. 
- `View()` does not create a subscription nor a cached value of the resulting type. Instead, the implementations of `Current()` and `Subscribe()` convert the upstream Refreshable's return values on every invocation. This reduces memory pressure for cheap or infrequent conversions like struct field accessors.
- `Merge()` combines two refreshables into one using a `reduceFn`. An update to either will refresh the reduced value.
- `Collect()` combines a list of refreshables of the same type into a refreshable slice type. 

This PR also adds some `Example*` tests to improve the package's godoc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/359)
<!-- Reviewable:end -->
