### PR TITLE
datetime and safelong: MarshalText implementations avoid string->[]byte conversion

### DIFF
--- a/datetime/datetime.go
+++ b/datetime/datetime.go
@@ -19,7 +19,7 @@ func (d DateTime) String() string {
 
 // MarshalText implements encoding.TextMarshaler (used by encoding/json and others).
 func (d DateTime) MarshalText() ([]byte, error) {
-	return []byte(d.String()), nil
+	return time.Time(d).AppendFormat(nil, time.RFC3339Nano), nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler (used by encoding/json and others).

--- a/safelong/safelong.go
+++ b/safelong/safelong.go
@@ -52,7 +52,7 @@ func (s SafeLong) MarshalJSON() ([]byte, error) {
 	if err := validate(int64(s)); err != nil {
 		return nil, err
 	}
-	return json.Marshal(int64(s))
+	return strconv.AppendInt(nil, int64(s), 10), nil
 }
 
 func validate(val int64) error {


### PR DESCRIPTION
The strings used in these implementations are allocated and immediately discarded

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/380)
<!-- Reviewable:end -->
