### PR TITLE
🐛 fix ToV2 missed-update race-condition

### DIFF
--- a/refreshable/v2.go
+++ b/refreshable/v2.go
@@ -15,6 +15,10 @@ func ToV2[T any](v1 Refreshable) refreshablev2.Refreshable[T] {
 	v1.Subscribe(func(i interface{}) {
 		v2.Update(i.(T))
 	})
+	// If v1 is updated before the subscription above is registered,
+	// the new v1 would have not propagated to v2.
+	// Here we enforce v2 has the latest v1.
+	v2.Update(v1.Current().(T))
 	return v2
 }
 

--- a/refreshable/v2_test.go
+++ b/refreshable/v2_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToFromV2(t *testing.T) {
@@ -22,4 +23,19 @@ func TestToFromV2(t *testing.T) {
 	assert.Equal(t, base.Current(), "updated", "base missing updated value")
 	assert.Equal(t, v2.Current(), "updated", "v2 missing updated value")
 	assert.Equal(t, v1.Current(), "updated", "v1 missing updated value")
+}
+
+func TestToV2RespectsUpdates(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		v1 := NewDefaultRefreshable(1)
+		updateCalled := make(chan struct{})
+		go func() {
+			require.NoError(t, v1.Update(2))
+			close(updateCalled)
+		}()
+		v2 := ToV2[int](v1)
+		<-updateCalled
+		assert.Equal(t, 2, v2.Current(),
+			"v2 should always be updated after Update is called")
+	}
 }


### PR DESCRIPTION
Due to the backing implementations of v1 refreshables not calling the subscription callback when the subscription is registered, there is a race condition where an update from the v1 refreshable is not propagated to the v2 refreshable if the update happens after the v2 is created and before the subscription is registered.

First commit provides failing test.
Second commit fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/381)
<!-- Reviewable:end -->
