### PR TITLE
refreshable: replace interface{} -> any

### DIFF
--- a/refreshable/main.go
+++ b/refreshable/main.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build module
-// +build module
 
 // This file exists only to smooth the transition for modules. Having this file makes it such that other modules that
 // consume this module will not have import path conflicts caused by github.com/palantir/pkg.

--- a/refreshable/refreshable.go
+++ b/refreshable/refreshable.go
@@ -6,12 +6,12 @@ package refreshable
 
 type Refreshable interface {
 	// Current returns the most recent value of this Refreshable.
-	Current() interface{}
+	Current() any
 
 	// Subscribe subscribes to changes of this Refreshable. The provided function is called with the value of Current()
 	// whenever the value changes.
-	Subscribe(consumer func(interface{})) (unsubscribe func())
+	Subscribe(consumer func(any)) (unsubscribe func())
 
 	// Map returns a new Refreshable based on the current one that handles updates based on the current Refreshable.
-	Map(func(interface{}) interface{}) Refreshable
+	Map(func(any) any) Refreshable
 }

--- a/refreshable/refreshable_default.go
+++ b/refreshable/refreshable_default.go
@@ -16,10 +16,10 @@ type DefaultRefreshable struct {
 	current *atomic.Value
 
 	sync.Mutex  // protects subscribers
-	subscribers []*func(interface{})
+	subscribers []*func(any)
 }
 
-func NewDefaultRefreshable(val interface{}) *DefaultRefreshable {
+func NewDefaultRefreshable(val any) *DefaultRefreshable {
 	current := atomic.Value{}
 	current.Store(val)
 
@@ -29,7 +29,7 @@ func NewDefaultRefreshable(val interface{}) *DefaultRefreshable {
 	}
 }
 
-func (d *DefaultRefreshable) Update(val interface{}) error {
+func (d *DefaultRefreshable) Update(val any) error {
 	d.Lock()
 	defer d.Unlock()
 
@@ -48,11 +48,11 @@ func (d *DefaultRefreshable) Update(val interface{}) error {
 	return nil
 }
 
-func (d *DefaultRefreshable) Current() interface{} {
+func (d *DefaultRefreshable) Current() any {
 	return d.current.Load()
 }
 
-func (d *DefaultRefreshable) Subscribe(consumer func(interface{})) (unsubscribe func()) {
+func (d *DefaultRefreshable) Subscribe(consumer func(any)) (unsubscribe func()) {
 	d.Lock()
 	defer d.Unlock()
 
@@ -63,7 +63,7 @@ func (d *DefaultRefreshable) Subscribe(consumer func(interface{})) (unsubscribe 
 	}
 }
 
-func (d *DefaultRefreshable) unsubscribe(consumerFnPtr *func(interface{})) {
+func (d *DefaultRefreshable) unsubscribe(consumerFnPtr *func(any)) {
 	d.Lock()
 	defer d.Unlock()
 
@@ -79,9 +79,9 @@ func (d *DefaultRefreshable) unsubscribe(consumerFnPtr *func(interface{})) {
 	}
 }
 
-func (d *DefaultRefreshable) Map(mapFn func(interface{}) interface{}) Refreshable {
+func (d *DefaultRefreshable) Map(mapFn func(any) any) Refreshable {
 	newRefreshable := NewDefaultRefreshable(mapFn(d.Current()))
-	d.Subscribe(func(updatedVal interface{}) {
+	d.Subscribe(func(updatedVal any) {
 		_ = newRefreshable.Update(mapFn(updatedVal))
 	})
 	return newRefreshable

--- a/refreshable/refreshable_default_test.go
+++ b/refreshable/refreshable_default_test.go
@@ -28,10 +28,10 @@ func TestDefaultRefreshable(t *testing.T) {
 
 	t.Run("Subscribe", func(t *testing.T) {
 		var v1, v2 container
-		unsub1 := r.Subscribe(func(i interface{}) {
+		unsub1 := r.Subscribe(func(i any) {
 			v1 = *(i.(*container))
 		})
-		_ = r.Subscribe(func(i interface{}) {
+		_ = r.Subscribe(func(i any) {
 			v2 = *(i.(*container))
 		})
 		assert.Equal(t, v1.Value, "")
@@ -51,7 +51,7 @@ func TestDefaultRefreshable(t *testing.T) {
 	t.Run("Map", func(t *testing.T) {
 		err := r.Update(&container{Value: "value"})
 		require.NoError(t, err)
-		m := r.Map(func(i interface{}) interface{} {
+		m := r.Map(func(i any) any {
 			return len(i.(*container).Value)
 		})
 		assert.Equal(t, m.Current(), 5)

--- a/refreshable/refreshable_types.go
+++ b/refreshable/refreshable_types.go
@@ -11,77 +11,77 @@ import (
 type String interface {
 	Refreshable
 	CurrentString() string
-	MapString(func(string) interface{}) Refreshable
+	MapString(func(string) any) Refreshable
 	SubscribeToString(func(string)) (unsubscribe func())
 }
 
 type StringPtr interface {
 	Refreshable
 	CurrentStringPtr() *string
-	MapStringPtr(func(*string) interface{}) Refreshable
+	MapStringPtr(func(*string) any) Refreshable
 	SubscribeToStringPtr(func(*string)) (unsubscribe func())
 }
 
 type StringSlice interface {
 	Refreshable
 	CurrentStringSlice() []string
-	MapStringSlice(func([]string) interface{}) Refreshable
+	MapStringSlice(func([]string) any) Refreshable
 	SubscribeToStringSlice(func([]string)) (unsubscribe func())
 }
 
 type Int interface {
 	Refreshable
 	CurrentInt() int
-	MapInt(func(int) interface{}) Refreshable
+	MapInt(func(int) any) Refreshable
 	SubscribeToInt(func(int)) (unsubscribe func())
 }
 
 type IntPtr interface {
 	Refreshable
 	CurrentIntPtr() *int
-	MapIntPtr(func(*int) interface{}) Refreshable
+	MapIntPtr(func(*int) any) Refreshable
 	SubscribeToIntPtr(func(*int)) (unsubscribe func())
 }
 
 type Int64 interface {
 	Refreshable
 	CurrentInt64() int64
-	MapInt64(func(int64) interface{}) Refreshable
+	MapInt64(func(int64) any) Refreshable
 	SubscribeToInt64(func(int64)) (unsubscribe func())
 }
 
 type Int64Ptr interface {
 	Refreshable
 	CurrentInt64Ptr() *int64
-	MapInt64Ptr(func(*int64) interface{}) Refreshable
+	MapInt64Ptr(func(*int64) any) Refreshable
 	SubscribeToInt64Ptr(func(*int64)) (unsubscribe func())
 }
 
 type Float64 interface {
 	Refreshable
 	CurrentFloat64() float64
-	MapFloat64(func(float64) interface{}) Refreshable
+	MapFloat64(func(float64) any) Refreshable
 	SubscribeToFloat64(func(float64)) (unsubscribe func())
 }
 
 type Float64Ptr interface {
 	Refreshable
 	CurrentFloat64Ptr() *float64
-	MapFloat64Ptr(func(*float64) interface{}) Refreshable
+	MapFloat64Ptr(func(*float64) any) Refreshable
 	SubscribeToFloat64Ptr(func(*float64)) (unsubscribe func())
 }
 
 type Bool interface {
 	Refreshable
 	CurrentBool() bool
-	MapBool(func(bool) interface{}) Refreshable
+	MapBool(func(bool) any) Refreshable
 	SubscribeToBool(func(bool)) (unsubscribe func())
 }
 
 type BoolPtr interface {
 	Refreshable
 	CurrentBoolPtr() *bool
-	MapBoolPtr(func(*bool) interface{}) Refreshable
+	MapBoolPtr(func(*bool) any) Refreshable
 	SubscribeToBoolPtr(func(*bool)) (unsubscribe func())
 }
 
@@ -89,14 +89,14 @@ type BoolPtr interface {
 type Duration interface {
 	Refreshable
 	CurrentDuration() time.Duration
-	MapDuration(func(time.Duration) interface{}) Refreshable
+	MapDuration(func(time.Duration) any) Refreshable
 	SubscribeToDuration(func(time.Duration)) (unsubscribe func())
 }
 
 type DurationPtr interface {
 	Refreshable
 	CurrentDurationPtr() *time.Duration
-	MapDurationPtr(func(*time.Duration) interface{}) Refreshable
+	MapDurationPtr(func(*time.Duration) any) Refreshable
 	SubscribeToDurationPtr(func(*time.Duration)) (unsubscribe func())
 }
 
@@ -201,14 +201,14 @@ func (rt refreshableTyped) CurrentString() string {
 	return rt.Current().(string)
 }
 
-func (rt refreshableTyped) MapString(mapFn func(string) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapString(mapFn func(string) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(string))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToString(subFn func(string)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(string))
 	})
 }
@@ -217,14 +217,14 @@ func (rt refreshableTyped) CurrentStringPtr() *string {
 	return rt.Current().(*string)
 }
 
-func (rt refreshableTyped) MapStringPtr(mapFn func(*string) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapStringPtr(mapFn func(*string) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(*string))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToStringPtr(subFn func(*string)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(*string))
 	})
 }
@@ -233,14 +233,14 @@ func (rt refreshableTyped) CurrentStringSlice() []string {
 	return rt.Current().([]string)
 }
 
-func (rt refreshableTyped) MapStringSlice(mapFn func([]string) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapStringSlice(mapFn func([]string) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.([]string))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToStringSlice(subFn func([]string)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.([]string))
 	})
 }
@@ -249,14 +249,14 @@ func (rt refreshableTyped) CurrentInt() int {
 	return rt.Current().(int)
 }
 
-func (rt refreshableTyped) MapInt(mapFn func(int) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapInt(mapFn func(int) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(int))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToInt(subFn func(int)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(int))
 	})
 }
@@ -265,14 +265,14 @@ func (rt refreshableTyped) CurrentIntPtr() *int {
 	return rt.Current().(*int)
 }
 
-func (rt refreshableTyped) MapIntPtr(mapFn func(*int) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapIntPtr(mapFn func(*int) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(*int))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToIntPtr(subFn func(*int)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(*int))
 	})
 }
@@ -281,14 +281,14 @@ func (rt refreshableTyped) CurrentInt64() int64 {
 	return rt.Current().(int64)
 }
 
-func (rt refreshableTyped) MapInt64(mapFn func(int64) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapInt64(mapFn func(int64) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(int64))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToInt64(subFn func(int64)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(int64))
 	})
 }
@@ -297,14 +297,14 @@ func (rt refreshableTyped) CurrentInt64Ptr() *int64 {
 	return rt.Current().(*int64)
 }
 
-func (rt refreshableTyped) MapInt64Ptr(mapFn func(*int64) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapInt64Ptr(mapFn func(*int64) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(*int64))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToInt64Ptr(subFn func(*int64)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(*int64))
 	})
 }
@@ -313,14 +313,14 @@ func (rt refreshableTyped) CurrentFloat64() float64 {
 	return rt.Current().(float64)
 }
 
-func (rt refreshableTyped) MapFloat64(mapFn func(float64) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapFloat64(mapFn func(float64) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(float64))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToFloat64(subFn func(float64)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(float64))
 	})
 }
@@ -329,14 +329,14 @@ func (rt refreshableTyped) CurrentFloat64Ptr() *float64 {
 	return rt.Current().(*float64)
 }
 
-func (rt refreshableTyped) MapFloat64Ptr(mapFn func(*float64) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapFloat64Ptr(mapFn func(*float64) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(*float64))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToFloat64Ptr(subFn func(*float64)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(*float64))
 	})
 }
@@ -345,14 +345,14 @@ func (rt refreshableTyped) CurrentBool() bool {
 	return rt.Current().(bool)
 }
 
-func (rt refreshableTyped) MapBool(mapFn func(bool) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapBool(mapFn func(bool) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(bool))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToBool(subFn func(bool)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(bool))
 	})
 }
@@ -361,14 +361,14 @@ func (rt refreshableTyped) CurrentBoolPtr() *bool {
 	return rt.Current().(*bool)
 }
 
-func (rt refreshableTyped) MapBoolPtr(mapFn func(*bool) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapBoolPtr(mapFn func(*bool) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(*bool))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToBoolPtr(subFn func(*bool)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(*bool))
 	})
 }
@@ -377,14 +377,14 @@ func (rt refreshableTyped) CurrentDuration() time.Duration {
 	return rt.Current().(time.Duration)
 }
 
-func (rt refreshableTyped) MapDuration(mapFn func(time.Duration) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapDuration(mapFn func(time.Duration) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(time.Duration))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToDuration(subFn func(time.Duration)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(time.Duration))
 	})
 }
@@ -393,14 +393,14 @@ func (rt refreshableTyped) CurrentDurationPtr() *time.Duration {
 	return rt.Current().(*time.Duration)
 }
 
-func (rt refreshableTyped) MapDurationPtr(mapFn func(*time.Duration) interface{}) Refreshable {
-	return rt.Map(func(i interface{}) interface{} {
+func (rt refreshableTyped) MapDurationPtr(mapFn func(*time.Duration) any) Refreshable {
+	return rt.Map(func(i any) any {
 		return mapFn(i.(*time.Duration))
 	})
 }
 
 func (rt refreshableTyped) SubscribeToDurationPtr(subFn func(*time.Duration)) (unsubscribe func()) {
-	return rt.Subscribe(func(i interface{}) {
+	return rt.Subscribe(func(i any) {
 		subFn(i.(*time.Duration))
 	})
 }

--- a/refreshable/refreshable_validating.go
+++ b/refreshable/refreshable_validating.go
@@ -26,8 +26,8 @@ func (v *ValidatingRefreshable) LastValidateErr() error {
 // NewValidatingRefreshable returns a new Refreshable whose current value is the latest value that passes the provided
 // validatingFn successfully. This returns an error if the current value of the passed in Refreshable does not pass the
 // validatingFn or if the validatingFn or Refreshable are nil.
-func NewValidatingRefreshable(origRefreshable Refreshable, validatingFn func(interface{}) error) (*ValidatingRefreshable, error) {
-	mappingFn := func(i interface{}) (interface{}, error) {
+func NewValidatingRefreshable(origRefreshable Refreshable, validatingFn func(any) error) (*ValidatingRefreshable, error) {
+	mappingFn := func(i any) (any, error) {
 		if err := validatingFn(i); err != nil {
 			return nil, err
 		}
@@ -39,11 +39,11 @@ func NewValidatingRefreshable(origRefreshable Refreshable, validatingFn func(int
 // NewMapValidatingRefreshable is similar to NewValidatingRefreshable but allows for the function to return a mapping/mutation
 // of the input object in addition to returning an error. The returned ValidatingRefreshable will contain the mapped value.
 // The mapped value must always be of the same type (but not necessarily that of the input type).
-func NewMapValidatingRefreshable(origRefreshable Refreshable, mappingFn func(interface{}) (interface{}, error)) (*ValidatingRefreshable, error) {
+func NewMapValidatingRefreshable(origRefreshable Refreshable, mappingFn func(any) (any, error)) (*ValidatingRefreshable, error) {
 	return newValidatingRefreshable(origRefreshable, mappingFn, true)
 }
 
-func newValidatingRefreshable(origRefreshable Refreshable, validatingFn func(interface{}) (interface{}, error), storeMappedVal bool) (*ValidatingRefreshable, error) {
+func newValidatingRefreshable(origRefreshable Refreshable, validatingFn func(any) (any, error), storeMappedVal bool) (*ValidatingRefreshable, error) {
 	if validatingFn == nil {
 		return nil, errors.New("failed to create validating Refreshable because the validating function was nil")
 	}
@@ -71,7 +71,7 @@ func newValidatingRefreshable(origRefreshable Refreshable, validatingFn func(int
 		lastValidateErr: &lastValidateErr,
 	}
 
-	updateValueFn := func(i interface{}) {
+	updateValueFn := func(i any) {
 		mappedVal, err := validatingFn(i)
 		if err != nil {
 			v.lastValidateErr.Store(errorWrapper{err})

--- a/refreshable/refreshable_validating_test.go
+++ b/refreshable/refreshable_validating_test.go
@@ -17,7 +17,7 @@ import (
 func TestValidatingRefreshable(t *testing.T) {
 	type container struct{ Value string }
 	r := refreshable.NewDefaultRefreshable(container{Value: "value"})
-	vr, err := refreshable.NewValidatingRefreshable(r, func(i interface{}) error {
+	vr, err := refreshable.NewValidatingRefreshable(r, func(i any) error {
 		if len(i.(container).Value) == 0 {
 			return errors.New("empty")
 		}
@@ -45,7 +45,7 @@ func TestValidatingRefreshable(t *testing.T) {
 
 func TestMapValidatingRefreshable(t *testing.T) {
 	r := refreshable.NewDefaultRefreshable("https://palantir.com:443")
-	vr, err := refreshable.NewMapValidatingRefreshable(r, func(i interface{}) (interface{}, error) {
+	vr, err := refreshable.NewMapValidatingRefreshable(r, func(i any) (any, error) {
 		return url.Parse(i.(string))
 	})
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestMapValidatingRefreshable(t *testing.T) {
 // if the underlying refreshable updates during the creation process.
 func TestValidatingRefreshable_SubscriptionRaceCondition(t *testing.T) {
 	r := &updateImmediatelyRefreshable{r: refreshable.NewDefaultRefreshable(1), newValue: 2}
-	vr, err := refreshable.NewValidatingRefreshable(r, func(i interface{}) error { return nil })
+	vr, err := refreshable.NewValidatingRefreshable(r, func(i any) error { return nil })
 	require.NoError(t, err)
 	// If this returns 1, it is likely because the VR contains a stale value
 	assert.Equal(t, 2, vr.Current())
@@ -80,19 +80,19 @@ func TestValidatingRefreshable_SubscriptionRaceCondition(t *testing.T) {
 // updateImmediatelyRefreshable is a mock implementation which updates to newValue immediately when Current() is called
 type updateImmediatelyRefreshable struct {
 	r        *refreshable.DefaultRefreshable
-	newValue interface{}
+	newValue any
 }
 
-func (r *updateImmediatelyRefreshable) Current() interface{} {
+func (r *updateImmediatelyRefreshable) Current() any {
 	c := r.r.Current()
 	_ = r.r.Update(r.newValue)
 	return c
 }
 
-func (r *updateImmediatelyRefreshable) Subscribe(f func(interface{})) func() {
+func (r *updateImmediatelyRefreshable) Subscribe(f func(any)) func() {
 	return r.r.Subscribe(f)
 }
 
-func (r *updateImmediatelyRefreshable) Map(f func(interface{}) interface{}) refreshable.Refreshable {
+func (r *updateImmediatelyRefreshable) Map(f func(any) any) refreshable.Refreshable {
 	return r.r.Map(f)
 }

--- a/refreshable/v2.go
+++ b/refreshable/v2.go
@@ -12,7 +12,7 @@ import (
 // If v1's value is not of type T, the function panics.
 func ToV2[T any](v1 Refreshable) refreshablev2.Refreshable[T] {
 	v2 := refreshablev2.New[T](v1.Current().(T))
-	v1.Subscribe(func(i interface{}) {
+	v1.Subscribe(func(i any) {
 		v2.Update(i.(T))
 	})
 	// If v1 is updated before the subscription above is registered,


### PR DESCRIPTION
Runs "go fix" on the refreshable package. The main change is that the references to "interface{}" are replaced with "any".

Even though this does not make a functional difference, it is helpful for repositories that generate code based on the signatures in this package, as it helps the output to remain compatible with "go fix".

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Replaces all instances of `interface{}` with `any`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/437)
<!-- Reviewable:end -->
