### PR TITLE
fix: use private clipackager cache

### DIFF
--- a/clipackager/clirunner.go
+++ b/clipackager/clirunner.go
@@ -25,18 +25,33 @@ import (
 // extension that represents the format of the archive.
 //
 // Assumes that the archive contains a top-level directory named "{cliName}-{cliVersion}", and that the CLI executable
-// is at {cliName}-{cliVersion}/bin/{cliName}, with ".bat" appended if the GOOS is windows. The directory
-// filepath.Join(os.TempDir(), "_"+cliName) is used as the package working directory.
+// is at {cliName}-{cliVersion}/bin/{cliName}, with ".bat" appended if the GOOS is windows. A stable package working
+// directory under os.UserCacheDir(), scoped by "clipackager" and cliName, is used so extracted CLIs remain reusable
+// across runs without relying on a shared temporary directory.
 func NewDefaultPackagedCLIRunner(
 	cliName,
 	cliVersion string,
 	archiveBytes []byte,
 	archiveExtension string,
 ) PackagedCLIRunner {
+	return newDefaultPackagedCLIRunner(cliName, cliVersion, archiveBytes, archiveExtension, os.UserCacheDir)
+}
+
+type userCacheDirFn func() (string, error)
+
+func newDefaultPackagedCLIRunner(
+	cliName,
+	cliVersion string,
+	archiveBytes []byte,
+	archiveExtension string,
+	cacheDirFn userCacheDirFn,
+) PackagedCLIRunner {
 	cliDirName := fmt.Sprintf("%s-%s", cliName, cliVersion)
-	return NewPackagedCLIRunner(
+	pkgWorkDir, pkgWorkDirErr := defaultPkgWorkDir(cliName, cacheDirFn)
+	return newPackagedCLIRunner(
 		cliDirName,
-		filepath.Join(os.TempDir(), "_"+cliName),
+		pkgWorkDir,
+		pkgWorkDirErr,
 		NewArchivePackagedCLIProviderFromBytes(
 			archiveBytes,
 			archiveExtension,
@@ -46,6 +61,28 @@ func NewDefaultPackagedCLIRunner(
 			),
 		),
 	)
+}
+
+func defaultPkgWorkDir(cliName string, cacheDirFn userCacheDirFn) (string, error) {
+	cacheRoot, err := cacheDirFn()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine user cache directory: %w", err)
+	}
+	if cacheRoot == "" {
+		return "", fmt.Errorf("failed to determine user cache directory: path was empty")
+	}
+	return filepath.Join(cacheRoot, "clipackager", cliName), nil
+}
+
+func normalizePkgWorkDir(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("package work directory path was empty")
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine absolute package work directory: %w", err)
+	}
+	return filepath.Clean(absPath), nil
 }
 
 // RunPackagedCLI is a convenience function that runs the CLI executable provided by packgedCLIRunner using the provided
@@ -65,12 +102,23 @@ type PackagedCLIRunner interface {
 	EnsureCLIExistsAndReturnPath() (string, error)
 }
 
-// NewPackagedCLIRunner returns a new PackagedCLIRunner that uses the provided parameters.
+// NewPackagedCLIRunner returns a new PackagedCLIRunner that uses the provided parameters. On Unix, pkgWorkDir and each
+// existing ancestor must be a real directory owned by root or the effective user and must not be group- or
+// world-writable. Missing path components are created with mode 0700. Violations are reported on first use before a
+// lock file is created or a cached executable is trusted.
 func NewPackagedCLIRunner(name, pkgWorkDir string, cliProvider PackagedCLIProvider) PackagedCLIRunner {
+	return newPackagedCLIRunner(name, pkgWorkDir, nil, cliProvider)
+}
+
+func newPackagedCLIRunner(name, pkgWorkDir string, pkgWorkDirErr error, cliProvider PackagedCLIProvider) PackagedCLIRunner {
+	if pkgWorkDirErr == nil {
+		pkgWorkDir, pkgWorkDirErr = normalizePkgWorkDir(pkgWorkDir)
+	}
 	return &packgedCLIRunner{
-		cliPkgName:  name,
-		pkgWorkDir:  pkgWorkDir,
-		cliProvider: cliProvider,
+		cliPkgName:    name,
+		pkgWorkDir:    pkgWorkDir,
+		pkgWorkDirErr: pkgWorkDirErr,
+		cliProvider:   cliProvider,
 	}
 }
 
@@ -91,12 +139,11 @@ type packgedCLIRunner struct {
 	// should be unique per package. Typically, the value is something like "{name}-{version}" (for example, "conjure-4.35.0").
 	cliPkgName string
 
-	// pkgWorkDir is the directory in which all package-related operations should occur. This directory may be used for
-	// things like lock files and as a parent directory within which archives may be written or extracted, so it should
-	// generally be assumed that the runner has full control over the directory. However, it may also make sense to have
-	// this be somewhat stable (rather than fully random) so that CLIs that have been set up can be reused across runs.
-	// For example, a value such as filepath.Join(os.TempDir(), "_conjureircli") is an example of such usage.
-	pkgWorkDir string
+	// pkgWorkDir is the directory in which all package-related operations should occur. The runner creates lock files and
+	// extracted CLI trees under this directory and therefore only uses directories that are safe to execute cached code
+	// from. Stable directories are expected and allow CLIs to be reused across runs.
+	pkgWorkDir    string
+	pkgWorkDirErr error
 
 	// cliProvider is the provider that extracts and writes the CLI if it does not exist.
 	cliProvider PackagedCLIProvider
@@ -105,6 +152,9 @@ type packgedCLIRunner struct {
 var _ PackagedCLIRunner = (*packgedCLIRunner)(nil)
 
 func (r *packgedCLIRunner) EnsureCLIExistsAndReturnPath() (string, error) {
+	if r.pkgWorkDirErr != nil {
+		return "", r.pkgWorkDirErr
+	}
 	cliPath, err := r.cliPath()
 	if err != nil {
 		return "", err
@@ -133,8 +183,8 @@ func (r *packgedCLIRunner) cliPath() (string, error) {
 // the CLI package name that locks across different processes/executables. Returns an error if the CLI does not exist at
 // the expected location and it was not possible to extract it.
 func (r *packgedCLIRunner) ensureCLIExists() error {
-	if err := os.MkdirAll(r.pkgWorkDir, 0755); err != nil {
-		return fmt.Errorf("os.MkdirAll failed for package work directory %s: %w", r.pkgWorkDir, err)
+	if err := ensurePkgWorkDir(r.pkgWorkDir); err != nil {
+		return fmt.Errorf("failed to prepare package work directory %s: %w", r.pkgWorkDir, err)
 	}
 	installPkgLockFilePath := filepath.Join(r.pkgWorkDir, fmt.Sprintf("install-%s.lock", r.cliPkgName))
 	installMutex := lockedfile.MutexAt(installPkgLockFilePath)

--- a/clipackager/clirunner_internal_test.go
+++ b/clipackager/clirunner_internal_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package clipackager
+
+import (
+	_ "embed"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var (
+	//go:embed testdata/single-executable.tgz
+	internalSingleExecutableTGZ []byte
+)
+
+func TestDefaultPkgWorkDirUsesStableUserCachePath(t *testing.T) {
+	cacheRoot := filepath.Join(t.TempDir(), "user-cache")
+	got, err := defaultPkgWorkDir("conjure", func() (string, error) {
+		return cacheRoot, nil
+	})
+	if err != nil {
+		t.Fatalf("defaultPkgWorkDir returned error: %v", err)
+	}
+
+	want := filepath.Join(cacheRoot, "clipackager", "conjure")
+	if got != want {
+		t.Fatalf("unexpected default package work directory:\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestNewDefaultPackagedCLIRunnerFailsClosedWhenUserCacheDirUnavailable(t *testing.T) {
+	runner := newDefaultPackagedCLIRunner(
+		"conjure",
+		"4.51.0",
+		nil,
+		".tgz",
+		func() (string, error) {
+			return "", errors.New("cache root unavailable")
+		},
+	)
+
+	_, err := runner.EnsureCLIExistsAndReturnPath()
+	if err == nil {
+		t.Fatal("expected error when user cache directory cannot be resolved")
+	}
+	if !strings.Contains(err.Error(), "failed to determine user cache directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewPackagedCLIRunnerNormalizesRelativeWorkDirOnce(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+
+	runner := NewPackagedCLIRunner("test-cli-1.0.0", filepath.Join("cache", "work"), nil)
+	got := runner.(*packgedCLIRunner).pkgWorkDir
+	want := filepath.Join(root, "cache", "work")
+	if got != want {
+		t.Fatalf("unexpected normalized package work directory:\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestResolvedUserCacheWorkDirReusesCachedCLI(t *testing.T) {
+	cacheRoot := trustedTempDir(t)
+	workDir, err := defaultPkgWorkDir("test-cli", func() (string, error) {
+		return cacheRoot, nil
+	})
+	if err != nil {
+		t.Fatalf("defaultPkgWorkDir returned error: %v", err)
+	}
+
+	newRunner := func() PackagedCLIRunner {
+		return NewPackagedCLIRunner(
+			"test-cli-1.0.0",
+			workDir,
+			NewArchivePackagedCLIProviderFromBytes(
+				internalSingleExecutableTGZ,
+				".tgz",
+				StaticPathProvider("test-cli.sh"),
+			),
+		)
+	}
+
+	path1, output1, err := RunPackagedCLI(newRunner())
+	if err != nil {
+		t.Fatalf("first run failed: %v", err)
+	}
+	path2, output2, err := RunPackagedCLI(newRunner())
+	if err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+
+	if path1 != path2 {
+		t.Fatalf("expected stable cached executable path:\nfirst:  %q\nsecond: %q", path1, path2)
+	}
+	if string(output1) != "Hello, world!\n" || string(output2) != "Hello, world!\n" {
+		t.Fatalf("unexpected output:\nfirst:  %q\nsecond: %q", string(output1), string(output2))
+	}
+}
+
+func trustedTempDir(t *testing.T) string {
+	t.Helper()
+
+	cacheRoot, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("failed to determine user cache directory for test: %v", err)
+	}
+	if err := os.MkdirAll(cacheRoot, 0700); err != nil {
+		t.Fatalf("failed to create user cache directory for test: %v", err)
+	}
+	tempDir, err := os.MkdirTemp(cacheRoot, "clipackager-test-*")
+	if err != nil {
+		t.Fatalf("failed to create trusted temporary directory for test: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Errorf("failed to remove trusted temporary directory %s: %v", tempDir, err)
+		}
+	})
+	return tempDir
+}

--- a/clipackager/clirunner_test.go
+++ b/clipackager/clirunner_test.go
@@ -6,6 +6,7 @@ package clipackager_test
 
 import (
 	_ "embed"
+	"os"
 	"strings"
 	"testing"
 
@@ -68,7 +69,7 @@ func TestRunCLI(t *testing.T) {
 			// Create a CLI runner with a unique work directory for this test
 			runner := clipackager.NewPackagedCLIRunner(
 				"test-cli-1.0.0",
-				t.TempDir(),
+				trustedTempDir(t),
 				cliProvider,
 			)
 
@@ -107,7 +108,7 @@ func TestRunCLIWithArgs(t *testing.T) {
 
 	runner := clipackager.NewPackagedCLIRunner(
 		"test-cli-1.0.0",
-		t.TempDir(),
+		trustedTempDir(t),
 		cliProvider,
 	)
 
@@ -129,7 +130,7 @@ func TestCLIExecutablePath(t *testing.T) {
 		clipackager.StaticPathProvider("hello-world-1.0.0/bin/test-cli.sh"),
 	)
 
-	workDir := t.TempDir()
+	workDir := trustedTempDir(t)
 	runner := clipackager.NewPackagedCLIRunner(
 		"test-cli-1.0.0",
 		workDir,
@@ -160,4 +161,26 @@ func TestCLIExecutablePath(t *testing.T) {
 	if execPath != execPath2 {
 		t.Errorf("executable path changed between calls:\nfirst:  %q\nsecond: %q", execPath, execPath2)
 	}
+}
+
+func trustedTempDir(t *testing.T) string {
+	t.Helper()
+
+	cacheRoot, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("failed to determine user cache directory for test: %v", err)
+	}
+	if err := os.MkdirAll(cacheRoot, 0700); err != nil {
+		t.Fatalf("failed to create user cache directory for test: %v", err)
+	}
+	tempDir, err := os.MkdirTemp(cacheRoot, "clipackager-test-*")
+	if err != nil {
+		t.Fatalf("failed to create trusted temporary directory for test: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Errorf("failed to remove trusted temporary directory %s: %v", tempDir, err)
+		}
+	})
+	return tempDir
 }

--- a/clipackager/doc.go
+++ b/clipackager/doc.go
@@ -10,6 +10,6 @@
 // The PackagedCLIProvider interface provides functions for extracting a CLI from an archive into a directory for use.
 //
 // The PackagedCLIRunner interface provides a function that ensures that a CLI exists using PackagedCLIProvider and
-// returns its path. The functionality is implemented in such a way that the CLI should generally be cached across
-// different runs and also uses file-based locking to ensure safety across processes.
+// returns its path. The default runner stores extracted CLIs in a per-user cache directory so they can be reused across
+// runs and uses file-based locking to ensure safety across processes.
 package clipackager

--- a/clipackager/workdir.go
+++ b/clipackager/workdir.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package clipackager
+
+import (
+	"fmt"
+	"os"
+)
+
+func ensurePkgWorkDir(path string) error {
+	if path == "" {
+		return fmt.Errorf("package work directory path was empty")
+	}
+	return ensurePkgWorkDirPlatform(path)
+}
+
+func validatePkgWorkDirEntry(path string, fi os.FileInfo) error {
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("package work directory component %s must not be a symlink", path)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("package work directory component %s is not a directory", path)
+	}
+	return nil
+}

--- a/clipackager/workdir_other.go
+++ b/clipackager/workdir_other.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !aix && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris
+
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package clipackager
+
+import (
+	"os"
+)
+
+func ensurePkgWorkDirPlatform(path string) error {
+	// This preserves the no-symlink/no-non-directory leaf invariant, but does not claim to validate platform ACLs.
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return err
+	}
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	return validatePkgWorkDirEntry(path, fi)
+}

--- a/clipackager/workdir_unix.go
+++ b/clipackager/workdir_unix.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package clipackager
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+func ensurePkgWorkDirPlatform(path string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("failed to resolve absolute package work directory %s: %w", path, err)
+	}
+	absPath = filepath.Clean(absPath)
+
+	current := string(filepath.Separator)
+	fi, err := os.Lstat(current)
+	if err != nil {
+		return fmt.Errorf("failed to inspect package work directory component %s: %w", current, err)
+	}
+	if err := validatePkgWorkDirUnix(current, fi); err != nil {
+		return err
+	}
+
+	relative := strings.TrimPrefix(absPath, current)
+	if relative == "" {
+		return nil
+	}
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		if component == "" {
+			continue
+		}
+		current = filepath.Join(current, component)
+		fi, err = os.Lstat(current)
+		if errors.Is(err, fs.ErrNotExist) {
+			if err := os.Mkdir(current, 0700); err != nil && !errors.Is(err, fs.ErrExist) {
+				return fmt.Errorf("failed to create package work directory component %s: %w", current, err)
+			}
+			fi, err = os.Lstat(current)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to inspect package work directory component %s: %w", current, err)
+		}
+		if err := validatePkgWorkDirUnix(current, fi); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePkgWorkDirUnix(path string, fi os.FileInfo) error {
+	if err := validatePkgWorkDirEntry(path, fi); err != nil {
+		return err
+	}
+	if fi.Mode().Perm()&0022 != 0 {
+		return fmt.Errorf("package work directory component %s is group or world writable: mode %o", path, fi.Mode().Perm())
+	}
+
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("could not determine owner of package work directory component %s", path)
+	}
+	if got, want := stat.Uid, uint32(os.Geteuid()); got != want && got != 0 {
+		return fmt.Errorf("package work directory component %s is owned by uid %d, expected uid %d or root", path, got, want)
+	}
+	return nil
+}

--- a/clipackager/workdir_unix_test.go
+++ b/clipackager/workdir_unix_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package clipackager
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsurePkgWorkDirRejectsSymlinkComponent(t *testing.T) {
+	parent := trustedTempDir(t)
+	target := filepath.Join(parent, "target")
+	if err := os.Mkdir(target, 0700); err != nil {
+		t.Fatalf("failed to create target directory: %v", err)
+	}
+	link := filepath.Join(parent, "cache-root")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	err := ensurePkgWorkDir(filepath.Join(link, "clipackager", "conjure"))
+	if err == nil {
+		t.Fatal("expected symlink path component to be rejected")
+	}
+	if !strings.Contains(err.Error(), "must not be a symlink") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsurePkgWorkDirRejectsStickyWorldWritableParentBeforeCreatingChildren(t *testing.T) {
+	parent := filepath.Join(trustedTempDir(t), "shared-cache")
+	if err := os.Mkdir(parent, 0700); err != nil {
+		t.Fatalf("failed to create parent directory: %v", err)
+	}
+	if err := os.Chmod(parent, 01777); err != nil {
+		t.Fatalf("failed to chmod parent directory: %v", err)
+	}
+
+	workDir := filepath.Join(parent, "clipackager", "conjure")
+	err := ensurePkgWorkDir(workDir)
+	if err == nil {
+		t.Fatal("expected world-writable ancestor to be rejected")
+	}
+	if !strings.Contains(err.Error(), "group or world writable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(parent, "clipackager")); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Fatalf("expected no child directories to be created below unsafe parent, got: %v", statErr)
+	}
+}
+
+func TestEnsurePkgWorkDirCreatesPrivateChildrenUnderTrustedAncestors(t *testing.T) {
+	workDir := filepath.Join(trustedTempDir(t), "cache-root", "clipackager", "conjure")
+	if err := ensurePkgWorkDir(workDir); err != nil {
+		t.Fatalf("expected trusted work directory to be accepted: %v", err)
+	}
+	fi, err := os.Stat(workDir)
+	if err != nil {
+		t.Fatalf("failed to stat created work directory: %v", err)
+	}
+	if got, want := fi.Mode().Perm(), os.FileMode(0700); got != want {
+		t.Fatalf("unexpected created work directory mode: want %o, got %o", want, got)
+	}
+}
+
+func TestPackagedCLIRunnerRejectsCacheHitUnderStickyWorldWritableParent(t *testing.T) {
+	sharedParent := filepath.Join(trustedTempDir(t), "shared-cache")
+	if err := os.Mkdir(sharedParent, 0700); err != nil {
+		t.Fatalf("failed to create shared parent directory: %v", err)
+	}
+	if err := os.Chmod(sharedParent, 01777); err != nil {
+		t.Fatalf("failed to chmod shared parent directory: %v", err)
+	}
+
+	workDir := filepath.Join(sharedParent, "clipackager", "conjure")
+	attackerCLI := filepath.Join(workDir, "conjure-1.0.0-extract-dir", "conjure")
+	if err := os.MkdirAll(filepath.Dir(attackerCLI), 0700); err != nil {
+		t.Fatalf("failed to create attacker-controlled cache tree: %v", err)
+	}
+	if err := os.WriteFile(attackerCLI, []byte("#!/bin/sh\necho attacker-controlled-cli\n"), 0700); err != nil {
+		t.Fatalf("failed to create attacker-controlled CLI: %v", err)
+	}
+
+	runner := NewPackagedCLIRunner(
+		"conjure-1.0.0",
+		workDir,
+		NewArchivePackagedCLIProviderFromBytes(nil, ".tgz", StaticPathProvider("conjure")),
+	)
+	_, output, err := RunPackagedCLI(runner)
+	if err == nil {
+		t.Fatalf("expected unsafe cache hit to be rejected before execution, got output %q", output)
+	}
+	if !strings.Contains(err.Error(), "group or world writable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

On Unix-based systems `cli` used a shared temp-dir to cache its CLIs under predictable paths. This becomes a problem on shared instances with multiple Unix users.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use user-based cache paths for temporary CLI cache
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/pkg/443)
<!-- Reviewable:end -->
